### PR TITLE
added option to add custom reprocessing image

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,3 @@ gem "delayed_job",  :require => false
 gem "delayed_job_active_record", :require => false
 
 gem "resque",       :require => false
-
-

--- a/README.textile
+++ b/README.textile
@@ -60,12 +60,12 @@ To have the missing image url be outputted by paperclip while the image is being
     def self.up
       add_column :users, :avatar_processing, :boolean
     end
-    
+
     def self.down
       remove_column :users, :avatar_processing
     end
   end
-  
+
   @user = User.new(:avatar => File.new(...))
   @user.save
   @user.avatar.url #=> "/images/original/missing.png"
@@ -74,6 +74,30 @@ To have the missing image url be outputted by paperclip while the image is being
   @user.reload
   @user.avatar.url #=> "/system/images/3/original/IMG_2772.JPG?1267562148"
 </code></pre>
+
+h4. Custom image for processing
+
+This is useful if you have a difference between missing images and images currently
+being processed.
+
+<pre><code>
+
+  class User < ActiveRecord::Base
+    has_attached_file :avatar
+
+    process_in_background :avatar, :processing_image_url => "/images/original/processing.jpg"
+  end
+
+  @user = User.new(:avatar => File.new(...))
+  @user.save
+  @user.avatar.url #=> "/images/original/processing.png"
+  Delayed::Worker.new.work_off
+
+  @user.reload
+  @user.avatar.url #=> "/system/images/3/original/IMG_2772.JPG?1267562148"
+
+</code></pre>
+
 
 h2. What if I'm not using images?
 

--- a/gemfiles/rails3.gemfile.lock
+++ b/gemfiles/rails3.gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: /home/jrg/code/delayed_paperclip
+  remote: /Users/ScotterC/code/github/delayed_paperclip
   specs:
     delayed_paperclip (2.5.0.1)
       paperclip (>= 3.3.0)

--- a/gemfiles/rails3_1.gemfile.lock
+++ b/gemfiles/rails3_1.gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: /home/jrg/code/delayed_paperclip
+  remote: /Users/ScotterC/code/github/delayed_paperclip
   specs:
     delayed_paperclip (2.5.0.1)
       paperclip (>= 3.3.0)

--- a/gemfiles/rails3_2.gemfile.lock
+++ b/gemfiles/rails3_2.gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: /home/jrg/code/delayed_paperclip
+  remote: /Users/ScotterC/code/github/delayed_paperclip
   specs:
     delayed_paperclip (2.5.0.1)
       paperclip (>= 3.3.0)

--- a/lib/delayed_paperclip.rb
+++ b/lib/delayed_paperclip.rb
@@ -10,7 +10,8 @@ module DelayedPaperclip
     def options
       @options ||= {
         :background_job_class => detect_background_task,
-        :url_with_processing  => true
+        :url_with_processing  => true,
+        :processing_image_url => nil
       }
     end
 
@@ -49,7 +50,8 @@ module DelayedPaperclip
       attachment_definitions[name][:delayed] = {}
       {
         :priority => 0,
-        :url_with_processing => DelayedPaperclip.options[:url_with_processing]
+        :url_with_processing => DelayedPaperclip.options[:url_with_processing],
+        :processing_image_url => options[:processing_image_url]
       }.each do |option, default|
         attachment_definitions[name][:delayed][option] = options.key?(option) ? options[option] : default
       end

--- a/lib/delayed_paperclip/url_generator.rb
+++ b/lib/delayed_paperclip/url_generator.rb
@@ -8,9 +8,13 @@ module DelayedPaperclip
 
     def most_appropriate_url_with_processed
       if @attachment.original_filename.nil? || delayed_default_url?
-        default_url
+        if @attachment.delayed_options[:processing_image_url].nil?
+          default_url
+        else
+          @attachment.delayed_options[:processing_image_url]
+        end
       else
-         @attachment_options[:url]
+        @attachment_options[:url]
       end
     end
 

--- a/test/base_delayed_paperclip_test.rb
+++ b/test/base_delayed_paperclip_test.rb
@@ -73,11 +73,20 @@ module BaseDelayedPaperclipTest
   def test_unprocessed_image_returns_missing_url
     dummy = Dummy.new(:image => File.open("#{RAILS_ROOT}/test/fixtures/12k.png"))
     dummy.save!
-    #assert_equal "/images/original/missing.png", dummy.image.url(:original, :timestamp => true)
-    dummy.image.url.starts_with?("/images/original/missing.png")
+    assert dummy.image.url.starts_with?("/images/original/missing.png")
     process_jobs
     dummy.reload
-    dummy.image.url.starts_with?("/system/images/1/original/12k.png")
+    assert dummy.image.url.starts_with?("/system/dummies/images/000/000/001/original/12k.png")
+  end
+
+  def test_unprocess_image_returns_reprocessing_url
+    reset_dummy :processing_image_url => "/images/original/processing.png"
+    dummy = Dummy.new(:image => File.open("#{RAILS_ROOT}/test/fixtures/12k.png"))
+    dummy.save!
+    assert dummy.image.url.starts_with?("/images/original/processing.png")
+    process_jobs
+    dummy.reload
+    assert dummy.image.url.starts_with?("/system/dummies/images/000/000/001/original/12k.png")
   end
 
   def test_unprocessed_image_not_returning_missing_url_if_turned_of_globally
@@ -85,27 +94,27 @@ module BaseDelayedPaperclipTest
     reset_dummy :with_processed => false
     dummy = Dummy.new(:image => File.open("#{RAILS_ROOT}/test/fixtures/12k.png"))
     dummy.save!
-    dummy.image.url.starts_with?("/system/images/1/original/12k.png")
+    assert dummy.image.url.starts_with?("/system/dummies/images/000/000/001/original/12k.png")
     process_jobs
     dummy.reload
-    dummy.image.url.starts_with?("/system/images/1/original/12k.png")
+    assert dummy.image.url.starts_with?("/system/dummies/images/000/000/001/original/12k.png")
   end
 
   def test_unprocessed_image_not_returning_missing_url_if_turned_of_on_instance
     reset_dummy :with_processed => false, :url_with_processing => false
     dummy = Dummy.new(:image => File.open("#{RAILS_ROOT}/test/fixtures/12k.png"))
     dummy.save!
-    dummy.image.url.starts_with?("/system/images/1/original/12k.png")
+    assert dummy.image.url.starts_with?("/system/dummies/images/000/000/001/original/12k.png")
     process_jobs
     dummy.reload
-    dummy.image.url.starts_with?("/system/images/1/original/12k.png")
+    assert dummy.image.url.starts_with?("/system/dummies/images/000/000/001/original/12k.png")
   end
 
   def test_original_url_when_no_processing_column
     reset_dummy :with_processed => false
     dummy = Dummy.new(:image => File.open("#{RAILS_ROOT}/test/fixtures/12k.png"))
     dummy.save!
-    dummy.image.url.starts_with?("/system/images/1/original/12k.png")  
+    assert dummy.reload.image.url.starts_with?("/system/dummies/images/000/000/001/original/12k.png")
   end
 
   def test_original_url_if_image_changed
@@ -113,9 +122,9 @@ module BaseDelayedPaperclipTest
     dummy.save!
     dummy.image = File.open("#{RAILS_ROOT}/test/fixtures/12k.png")
     dummy.save!
-    dummy.image.url.starts_with?("/images/original/missing.png")
+    assert dummy.image.url.starts_with?("/images/original/missing.png")
     process_jobs
-    dummy.image.url.starts_with?("/system/images/1/original/12k.png")
+    assert dummy.reload.image.url.starts_with?("/system/dummies/images/000/000/001/original/12k.png")
   end
 
   def test_missing_url_if_image_hasnt_changed

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -57,6 +57,7 @@ def reset_class(class_name, options)
   klass.class_eval do
     include Paperclip::Glue
     has_attached_file     :image
+
     process_in_background :image, options if options[:with_processed]
     after_update :reprocess if options[:with_after_update_callback]
 


### PR DESCRIPTION
Added the option to use a custom reprocessing image instead of relying on the default paperclip url.  This is useful if you have users who upload images who want immediate feedback where as you also want to figure out what images are actually missing.

Also, while writing tests I came across a bunch that didn't have the `assert` to make actually test the paths for some images.  I added the assert and corrected the paths to work with Paperclip 3.3's default path.

Added a small bit to the Readme to reflect changes.  
