### PR TITLE
Don't append timestamp to default url while processing

### DIFF
--- a/lib/delayed_paperclip/url_generator.rb
+++ b/lib/delayed_paperclip/url_generator.rb
@@ -4,6 +4,7 @@ module DelayedPaperclip
     def self.included(base)
       base.send :include, InstanceMethods
       base.alias_method_chain :most_appropriate_url, :processed
+      base.alias_method_chain :timestamp_possible?, :processed
     end
 
     def most_appropriate_url_with_processed
@@ -11,6 +12,14 @@ module DelayedPaperclip
         default_url
       else
          @attachment_options[:url]
+      end
+    end
+    
+    def timestamp_possible_with_processed?
+      if delayed_default_url?
+        false
+      else
+        timestamp_possible_without_processed?
       end
     end
 


### PR DESCRIPTION
In paperclip timestamps are never appended when a default url is returned. But while a delayed paperclip job is processing, it does append a timestamp to the default url.

This causes problems if you set your default url to use an image from your sprockets assets. Since it won't be able to find it when a timestamp is appended.

Attached code fixes the issue.
