### PR TITLE
Use default_url when no file is provided or is not processing

### DIFF
--- a/lib/delayed_paperclip/url_generator.rb
+++ b/lib/delayed_paperclip/url_generator.rb
@@ -9,7 +9,7 @@ module DelayedPaperclip
 
     def most_appropriate_url_with_processed
       if @attachment.original_filename.nil? || delayed_default_url?
-        if @attachment.delayed_options.nil? || @attachment.delayed_options[:processing_image_url].nil?
+        if @attachment.delayed_options.nil? || @attachment.delayed_options[:processing_image_url].nil? || !@attachment.processing?
           default_url
         else
           @attachment.delayed_options[:processing_image_url]

--- a/test/base_delayed_paperclip_test.rb
+++ b/test/base_delayed_paperclip_test.rb
@@ -110,6 +110,20 @@ module BaseDelayedPaperclipTest
     assert dummy.image.url.starts_with?("/system/dummies/images/000/000/001/original/12k.png")
   end
 
+  def test_unprocessed_processing_url_when_file
+    reset_dummy :with_processed => true, :processing_image_url => "processing"
+    dummy = Dummy.new(:image => File.open("#{RAILS_ROOT}/test/fixtures/12k.png"))
+    dummy.save!
+    assert dummy.reload.image.url.starts_with?("processing")
+  end
+
+  def test_processed_default_url_when_no_file
+    reset_dummy :with_processed => true, :processing_image_url => "processing"
+    dummy = Dummy.new()
+    dummy.save!
+    assert dummy.reload.image.url.starts_with?("/images/original/missing.png")
+  end
+
   def test_original_url_when_no_processing_column
     reset_dummy :with_processed => false
     dummy = Dummy.new(:image => File.open("#{RAILS_ROOT}/test/fixtures/12k.png"))


### PR DESCRIPTION
When no file is provided, delayed_paperclip did not fall back onto default_url, and instead only did that when there was no image_processing_url.

The desired functionality when having a nil file is to use the default_url.
The desired functionality when having a processing file is to use the processing_url.

This pull request provides that feature as well as testing for both of these desired scenarios.
