### PR TITLE
Refactor away deprecation warning for Rails 4

### DIFF
--- a/lib/delayed_paperclip.rb
+++ b/lib/delayed_paperclip.rb
@@ -75,7 +75,7 @@ module DelayedPaperclip
       unless @_enqued_for_processing_with_processing.blank? # catches nil and empty arrays
         updates = @_enqued_for_processing_with_processing.collect{|n| "#{n}_processing = :true" }.join(", ")
         updates = ActiveRecord::Base.send(:sanitize_sql_array, [updates, {:true => true}])
-        self.class.update_all(updates, "id = #{self.id}")
+        self.class.where(:id => self.id).update_all(updates)
       end
     end
 

--- a/lib/delayed_paperclip/attachment.rb
+++ b/lib/delayed_paperclip/attachment.rb
@@ -71,7 +71,7 @@ module DelayedPaperclip
         # instance.update_column("#{name}_processing", false) if instance.respond_to?(:"#{name}_processing?")
         if instance.respond_to?(:"#{name}_processing?")
           instance.send("#{name}_processing=", false)
-          instance.class.update_all({ "#{name}_processing" => false }, instance.class.primary_key => instance.id)
+          instance.class.where(instance.class.primary_key => instance.id).update_all({ "#{name}_processing" => false })
         end
       end
 


### PR DESCRIPTION
This just removes a deprecation warning when used in Rails 4.
