### PR TITLE
fixing issue that caused #{name}_processing to be set incorrectly to false after a second save

### DIFF
--- a/lib/delayed_paperclip.rb
+++ b/lib/delayed_paperclip.rb
@@ -30,9 +30,11 @@ module DelayedPaperclip
     end
 
     def process_job(instance_klass, instance_id, attachment_name)
-      instance_klass.constantize.find(instance_id).
-        send(attachment_name).
-        process_delayed!
+      instance = instance_klass.constantize.find(instance_id)
+      instance.send(attachment_name).process_delayed!
+        
+      instance.send("#{attachment_name}_processing=", false)
+      instance.class.where(instance.class.primary_key => instance.id).update_all({ "#{attachment_name}_processing" => false })
     end
 
   end

--- a/lib/delayed_paperclip/attachment.rb
+++ b/lib/delayed_paperclip/attachment.rb
@@ -58,7 +58,7 @@ module DelayedPaperclip
         # update_column is available in rails 3.1 instead we can do this to update the attribute without callbacks
 
         # instance.update_column("#{name}_processing", false) if instance.respond_to?(:"#{name}_processing?")
-        if instance.respond_to?(:"#{name}_processing?")
+        if instance.respond_to?(:"#{name}_processing?") && !instance.send("#{name}_processing")
           instance.send("#{name}_processing=", false)
           instance.class.where(instance.class.primary_key => instance.id).update_all({ "#{name}_processing" => false })
         end


### PR DESCRIPTION
fixes this issue: https://github.com/jrgifford/delayed_paperclip/issues/52
