### PR TITLE
Allow only_process through process_in_background

### DIFF
--- a/gemfiles/rails2.gemfile.lock
+++ b/gemfiles/rails2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
-  remote: /Users/maguilar/code/data-engineering/vendor/plugins/delayed_paperclip
+  remote: ..
   specs:
-    delayed_paperclip (2.4.5.1)
+    delayed_paperclip (2.4.5.2)
       paperclip (>= 2.4.5)
 
 GEM

--- a/gemfiles/rails3.gemfile.lock
+++ b/gemfiles/rails3.gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: /Users/maguilar/code/data-engineering/vendor/plugins/delayed_paperclip
+  remote: ..
   specs:
     delayed_paperclip (2.4.5.1)
       paperclip (>= 2.4.5)

--- a/gemfiles/rails3_1.gemfile.lock
+++ b/gemfiles/rails3_1.gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: /home/jrg/code/delayed_paperclip
+  remote: ..
   specs:
     delayed_paperclip (2.4.5.1)
       paperclip (>= 2.4.5)

--- a/lib/delayed_paperclip.rb
+++ b/lib/delayed_paperclip.rb
@@ -54,6 +54,10 @@ module DelayedPaperclip
         attachment_definitions[name][:delayed][option] = options.key?(option) ? options[option] : default
       end
 
+      if options.has_key? :only_process
+        attachment_definitions[name][:only_process] = options[:only_process]
+      end
+
       if respond_to?(:after_commit)
         after_commit  :enqueue_delayed_processing
       else

--- a/test/base_delayed_paperclip_test.rb
+++ b/test/base_delayed_paperclip_test.rb
@@ -147,4 +147,13 @@ module BaseDelayedPaperclipTest
     dummy.update_attributes(:name => "hi")
   end
 
+  def test_only_process_is_passed_to_paperclip
+    reset_dummy :paperclip => { 
+                  :styles => { :foo => "12x12", :bar => "10x10" } 
+                }, 
+                :only_process => [:foo]
+
+    assert Dummy.attachment_definitions[:image].has_key? :only_process
+    assert_equal [:foo], Dummy.attachment_definitions[:image][:only_process]
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,12 +51,15 @@ def build_dummy_table(with_processed)
 end
 
 def reset_class(class_name, options)
+  options[:paperclip] = {} if options[:paperclip].nil?
   ActiveRecord::Base.send(:include, Paperclip::Glue)
   Object.send(:remove_const, class_name) rescue nil
   klass = Object.const_set(class_name, Class.new(ActiveRecord::Base))
   klass.class_eval do
     include Paperclip::Glue
-    has_attached_file     :image
+    has_attached_file :image, options[:paperclip]
+    options.delete :paperclip
+
     process_in_background :image, options if options[:with_processed]
     after_update :reprocess if options[:with_after_update_callback]
 


### PR DESCRIPTION
Hello, thanks for this gem. I'm still struggling to get it work with:
- Rails (2.3.18)
- Paperclip (2.7.5)
- DelayedJob (2.0.7)

Although this fix allows to pass the option `only_process` to the paperclip options there is another problematic issue. only_process is not working as intended...

What I'm really confused at the moment is the fact that on [paperclip implementation](https://github.com/thoughtbot/paperclip/blob/v2.7/lib/paperclip/attachment.rb#L122) it will only do the `only_process` if `post_processing` returns true. On your current [implementation](https://github.com/jrgifford/delayed_paperclip/blob/rails2/lib/delayed_paperclip/attachment.rb#L16) this always returns `false`. Is this a bug? 
