### PR TITLE
Fix undefined method `[]' for nil:NilClass with Paperclip 3.5.2

### DIFF
--- a/lib/delayed_paperclip/attachment.rb
+++ b/lib/delayed_paperclip/attachment.rb
@@ -13,7 +13,7 @@ module DelayedPaperclip
     module InstanceMethods
 
       def delayed_options
-        @instance.class.paperclip_definitions[@name][:delayed]
+        @instance.class.paperclip_definitions[@name][:delayed] unless @instance.class.paperclip_definitions[@name].nil?
       end
 
       # Attr accessor in Paperclip


### PR DESCRIPTION
This PR fixes the issue :  https://github.com/jrgifford/delayed_paperclip/issues/66

`Stacktrace :
NoMethodError: undefined method `[]' for nil:NilClass
    from /Users/vincentdaubry/.rvm/gems/ruby-2.0.0-p247@yb-web/bundler/gems/delayed_paperclip-f9c5cf6c3049/lib/delayed_paperclip/attachment.rb:16:in `delayed_options'
    from /Users/vincentdaubry/.rvm/gems/ruby-2.0.0-p247@yb-web/bundler/gems/delayed_paperclip-f9c5cf6c3049/lib/delayed_paperclip/attachment.rb:32:in `delay_processing?'
    from /Users/vincentdaubry/.rvm/gems/ruby-2.0.0-p247@yb-web/bundler/gems/delayed_paperclip-f9c5cf6c3049/lib/delayed_paperclip/attachment.rb:71:in `block in save_with_prepare_enqueueing'
    from /Users/vincentdaubry/.rvm/gems/ruby-2.0.0-p247@yb-web/gems/andand-1.3.3/lib/andand.rb:60:in `me'
    from /Users/vincentdaubry/.rvm/gems/ruby-2.0.0-p247@yb-web/bundler/gems/delayed_paperclip-f9c5cf6c3049/lib/delayed_paperclip/attachment.rb:70:in `save_with_prepare_enqueueing'
    from /Users/vincentdaubry/.rvm/gems/ruby-2.0.0-p247@yb-web/gems/paperclip-3.5.2/lib/paperclip/has_attached_file.rb:82:in `block in add_active_record_callbacks'
    from /Users/vincentdaubry/.rvm/gems/ruby-2.0.0-p247@yb-web/gems/activesupport-3.2.16/lib/active_support/callbacks.rb:416:in `_run__1272238574363903200__save__3446927020163813569__callbacks'
    from /Users/vincentdaubry/.rvm/gems/ruby-2.0.0-p247@yb-web/gems/activesupport-3.2.16/lib/active_support/callbacks.rb:405:in `__run_callback'
    from /Users/vincentdaubry/.rvm/gems/ruby-2.0.0-p247@yb-web/gems/activesupport-3.2.16/lib/active_support/callbacks.rb:385:in `_run_save_callbacks'
    from /Users/vincentdaubry/.rvm/gems/ruby-2.0.0-p247@yb-web/gems/activesupport-3.2.16/lib/active_support/callbacks.rb:81:in `run_callbacks'
    from /Users/vincentdaubry/.rvm/gems/ruby-2.0.0-p247@yb-web/gems/activerecord-3.2.16/lib/active_record/callbacks.rb:264:in `create_or_update'
    from /Users/vincentdaubry/.rvm/gems/ruby-2.0.0-p247@yb-web/gems/activerecord-3.2.16/lib/active_record/persistence.rb:84:in `save'
    from /Users/vincentdaubry/.rvm/gems/ruby-2.0.0-p247@yb-web/gems/activerecord-3.2.16/lib/active_record/validations.rb:50:in `save'
    from /Users/vincentdaubry/.rvm/gems/ruby-2.0.0-p247@yb-web/gems/activerecord-3.2.16/lib/active_record/attribute_methods/dirty.rb:22:in `save'
    from /Users/vincentdaubry/.rvm/gems/ruby-2.0.0-p247@yb-web/gems/activerecord-3.2.16/lib/active_record/transactions.rb:259:in `block (2 levels) in save'
    from /Users/vincentdaubry/.rvm/gems/ruby-2.0.0-p247@yb-web/gems/activerecord-3.2.16/lib/active_record/transactions.rb:313:in `block in with_transaction_returning_status'`
