### PR TITLE
fix undefined method `[]' for nil:NilClass, Issue#66

### DIFF
--- a/lib/delayed_paperclip/attachment.rb
+++ b/lib/delayed_paperclip/attachment.rb
@@ -53,7 +53,7 @@ module DelayedPaperclip
       end
 
       def processing_image_url
-        processing_image_url = @options[:delayed][:processing_image_url]
+        processing_image_url = delayed_options[:processing_image_url]
         processing_image_url = processing_image_url.call(self) if processing_image_url.respond_to?(:call)
         processing_image_url
       end


### PR DESCRIPTION
@options was not reading :delayed in the hash, however, delayed_options method was. Seeing as @options is not used anywhere else in Attachment module and delayed_options is used multiple times I feel this is not only a fix but an improvement.
