### PR TITLE
fix default urs for split processing

### DIFF
--- a/lib/delayed_paperclip/attachment.rb
+++ b/lib/delayed_paperclip/attachment.rb
@@ -34,15 +34,22 @@ module DelayedPaperclip
           !@post_processing_with_delay
         end
       end
-      
+
       def split_processing?
-        @instance.class.paperclip_definitions[@name][:only_process] && 
-          @instance.class.paperclip_definitions[@name][:only_process] != 
-            @instance.class.paperclip_definitions[@name][:delayed][:only_process]
+        @instance.class.paperclip_definitions[@name][:only_process] &&
+          @instance.class.paperclip_definitions[@name][:only_process] !=
+            delayed_options[:only_process]
       end
 
       def processing?
-        @instance.send(:"#{@name}_processing?")
+        column_name = :"#{@name}_processing?"
+        @instance.respond_to?(column_name) && @instance.send(column_name)
+      end
+
+      def processing_style?(style)
+        return false if !processing?
+
+        !split_processing? || delayed_options[:only_process].include?(style)
       end
 
       def process_delayed!

--- a/lib/delayed_paperclip/url_generator.rb
+++ b/lib/delayed_paperclip/url_generator.rb
@@ -5,10 +5,21 @@ module DelayedPaperclip
     def self.included(base)
       base.alias_method_chain :most_appropriate_url, :processed
       base.alias_method_chain :timestamp_possible?, :processed
+      base.alias_method_chain :for, :processed
     end
 
-    def most_appropriate_url_with_processed
-      if @attachment.original_filename.nil? || delayed_default_url?
+    def for_with_processed(style_name, options)
+      most_appropriate_url = most_appropriate_url(style_name)
+
+      escape_url_as_needed(
+        timestamp_as_needed(
+          @attachment_options[:interpolator].interpolate(most_appropriate_url, @attachment, style_name),
+          options
+      ), options)
+    end
+
+    def most_appropriate_url_with_processed(style = nil)
+      if @attachment.original_filename.nil? || delayed_default_url?(style)
         if @attachment.delayed_options.nil? || @attachment.processing_image_url.nil? || !@attachment.processing?
           default_url
         else
@@ -27,11 +38,11 @@ module DelayedPaperclip
       end
     end
 
-    def delayed_default_url?
+    def delayed_default_url?(style = nil)
       return false if @attachment.job_is_processing
       return false if @attachment.dirty?
       return false if not @attachment.delayed_options.try(:[], :url_with_processing)
-      return false if not (@attachment.instance.respond_to?(:"#{@attachment.name}_processing?") && @attachment.processing?)
+      return false if not processing?(style)
       true
 
       # OLD CRAZY CONDITIONAL
@@ -42,6 +53,13 @@ module DelayedPaperclip
       #   !@attachment.delayed_options.try(:[], :url_with_processing) ||
       #   !(@attachment.instance.respond_to?(:"#{@attachment.name}_processing?") && @attachment.processing?)
       # )
+    end
+
+    private
+    def processing?(style)
+      return true if @attachment.processing?
+
+      return @attachment.processing_style?(style) if style
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,21 +36,23 @@ Dir["./spec/integration/examples/*.rb"].sort.each {|f| require f}
 
 # Reset table and class with image_processing column or not
 def reset_dummy(options = {})
+
   options[:with_processed] = true unless options.key?(:with_processed)
-  build_dummy_table(options[:with_processed])
+  options[:processed_column] = options[:with_processed] unless options.has_key?(:processed_column)
+  build_dummy_table(options.delete(:processed_column))
   reset_class("Dummy", options)
 end
 
 # Dummy Table for images
 # with or without image_processing column
-def build_dummy_table(with_processed)
+def build_dummy_table(with_column)
   ActiveRecord::Base.connection.create_table :dummies, :force => true do |t|
     t.string   :name
     t.string   :image_file_name
     t.string   :image_content_type
     t.integer  :image_file_size
     t.datetime :image_updated_at
-    t.boolean(:image_processing, :default => false) if with_processed
+    t.boolean(:image_processing, :default => false) if with_column
   end
 end
 


### PR DESCRIPTION
When doing split processing, we have some styles already available, even
though the background processing is still ongoing. We must return those
instead of the missing picture url
