### PR TITLE
Fixed bug on models with multiple attachments

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,13 +46,13 @@ Dir["./spec/integration/examples/*.rb"].sort.each {|f| require f}
 def reset_dummy(options = {})
   options[:with_processed] = true unless options.key?(:with_processed)
   options[:processed_column] = options[:with_processed] unless options.has_key?(:processed_column)
-  build_dummy_table(options.delete(:processed_column))
+  build_dummy_table(options.delete(:processed_column), options[:multiple_attachments])
   reset_class("Dummy", options)
 end
 
 # Dummy Table for images
 # with or without image_processing column
-def build_dummy_table(with_column)
+def build_dummy_table(with_column, multiple_attachments = false)
   ActiveRecord::Base.connection.create_table :dummies, :force => true do |t|
     t.string   :name
     t.string   :image_file_name
@@ -60,6 +60,14 @@ def build_dummy_table(with_column)
     t.integer  :image_file_size
     t.datetime :image_updated_at
     t.boolean(:image_processing, :default => false) if with_column
+
+    if multiple_attachments
+      t.string   :alt_image_file_name
+      t.string   :alt_image_content_type
+      t.integer  :alt_image_file_size
+      t.datetime :alt_image_updated_at
+      t.boolean(:alt_image_processing, :default => false) if with_column
+    end
   end
 end
 
@@ -77,6 +85,7 @@ def reset_class(class_name, options)
     include Paperclip::Glue
 
     has_attached_file :image, options[:paperclip]
+    (has_attached_file :alt_image, options[:paperclip]) if options[:multiple_attachments]
     options.delete(:paperclip)
 
     validates_attachment :image, :content_type => { :content_type => "image/png" }

--- a/test/base_delayed_paperclip_test.rb
+++ b/test/base_delayed_paperclip_test.rb
@@ -247,42 +247,4 @@ module BaseDelayedPaperclipTest
     assert dummy.image.url.starts_with?("/system/dummies/images/000/000/001/original/12k.png")
   end
 
-  def test_model_with_multiple_attachments_doesnt_mark_all_done_processing_when_just_one_is_done
-    ActiveRecord::Base.connection.create_table :alt_dummies, :force => true do |t|
-      t.string   :name
-
-      t.string   :image_file_name
-      t.string   :image_content_type
-      t.integer  :image_file_size
-      t.datetime :image_updated_at
-      t.boolean  :image_processing, :default => false
-
-      t.string   :alt_image_file_name
-      t.string   :alt_image_content_type
-      t.integer  :alt_image_file_size
-      t.datetime :alt_image_updated_at
-      t.boolean  :alt_image_processing, :default => false
-    end
-
-    reset_class("AltDummy", {with_processed: true})
-
-    AltDummy.class_eval do
-      has_attached_file :alt_image
-      process_in_background :alt_image
-    end
-
-    alt_dummy = AltDummy.new(
-      image:     File.open("#{ROOT}/test/fixtures/12k.png"),
-      alt_image: File.open("#{ROOT}/test/fixtures/12k.png")
-    )
-
-    assert !alt_dummy.image_processing?
-    assert !alt_dummy.alt_image_processing?
-    assert alt_dummy.save
-
-    alt_dummy.image_processing = false
-    assert alt_dummy.save
-    assert !alt_dummy.image_processing?
-    assert alt_dummy.alt_image_processing?
-  end
 end


### PR DESCRIPTION
It used to be, if you had a model with multiple attachments, once one was marked as no longer processing, _all_ attachments on that model were mistakenly marked as no longer processing.

This is now fixed.
