### PR TITLE
Dynamic only_process support

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -114,6 +114,16 @@ This is useful if you don't want the background job to reprocess all styles.
   end
 </code></pre>
 
+Like paperclip, you could also supply a lambda function to define only_process dynamically.
+
+<pre><code>
+  class User < ActiveRecord::Base
+    has_attached_file :avatar, :styles => { :small => "25x25#", :medium => "50x50x" }
+
+    process_in_background :avatar, :only_process => lambda { |a| a.instance.small_supported? ? [:small, :large] : [:large] }
+  end
+</code></pre>
+
 h4. Split processing
 
 You can process some styles in the foreground and some in the background by setting only_process on both has_attached_file and process_in_background.

--- a/lib/delayed_paperclip/attachment.rb
+++ b/lib/delayed_paperclip/attachment.rb
@@ -51,10 +51,16 @@ module DelayedPaperclip
         !split_processing? || delayed_options[:only_process].include?(style)
       end
 
+      def delayed_only_process
+        only_process = delayed_options[:only_process].dup
+        only_process = only_process.call(self) if only_process.respond_to?(:call)
+        only_process.map(&:to_sym)
+      end
+
       def process_delayed!
         self.job_is_processing = true
         self.post_processing = true
-        reprocess!(*delayed_options[:only_process])
+        reprocess!(*delayed_only_process)
         self.job_is_processing = false
         update_processing_column
       end

--- a/spec/delayed_paperclip/attachment_spec.rb
+++ b/spec/delayed_paperclip/attachment_spec.rb
@@ -107,6 +107,34 @@ describe DelayedPaperclip::Attachment do
     end
   end
 
+  describe "delayed_only_process" do
+    context "without only_process options" do
+      it "returns []" do
+        expect(dummy.image.delayed_only_process).to eq []
+      end
+    end
+
+    context "with only_process options" do
+      before :each do
+        reset_dummy(paperclip: { only_process: [:small, :large] } )
+      end
+
+      it "returns [:small, :large]" do
+        expect(dummy.image.delayed_only_process).to eq [:small, :large]
+      end
+    end
+
+    context "with only_process set with callable" do
+      before :each do
+        reset_dummy(paperclip: { only_process: lambda { |a| [:small, :large] } } )
+      end
+
+      it "returns [:small, :large]" do
+        expect(dummy.image.delayed_only_process).to eq [:small, :large]
+      end
+    end
+  end
+
   describe "process_delayed!" do
     it "sets job_is_processing to true" do
       dummy.image.expects(:job_is_processing=).with(true).once
@@ -129,6 +157,17 @@ describe DelayedPaperclip::Attachment do
     context "with only_process options" do
       before :each do
         reset_dummy(paperclip: { only_process: [:small, :large] } )
+      end
+
+      it "calls reprocess! with options" do
+        dummy.image.expects(:reprocess!).with(:small, :large)
+        dummy.image.process_delayed!
+      end
+    end
+
+    context "with only_process set with callable" do
+      before :each do
+        reset_dummy(paperclip: { only_process: lambda { |a| [:small, :large] } } )
       end
 
       it "calls reprocess! with options" do


### PR DESCRIPTION
Enables lambda support for the only_process option to determine which
styles need to be processed delayed dynamically. This is supported in the generic paperclip gem, adding it to the delayed_paperclip gem allows you to process certain styles on attachments that support multiple file types as well.

```
process_in_background :avatar, :only_process => lambda { |a| a.instance.small_supported? ? [:small, :large] : [:large] }
```
