### PR TITLE
[docs] Adding a section about 'url_with_processing.'

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -104,8 +104,12 @@ being processed.
 
 h4. Have processing? status available, but construct image URLs as if delayed_paperclip wasn't present
 
-If you define the #{attachment_name}_processing column, but set the url_with_processing option to false, this opens up other options (other than modifying the url that paperclip returns) for giving feedback to the user while the image is processing.  This is useful for advanced situations, for example when dealing
+If you define the #{attachment_name}_processing column, but set the url_with_processing option to false,
+this opens up other options (other than modifying the url that paperclip returns) for giving feedback to
+the user while the image is processing.  This is useful for advanced situations, for example when dealing
 with caching systems.
+
+Note especially the method .processing? which passes through the value of the boolean created via migration.
 
 <pre><code>
 


### PR DESCRIPTION
On a CMS that I host on Heroku, my users were uploading animated gifs, which could not be resized within the 25s Heroku timeout.  delayed_paperclip made it easy to move the  resizing into a worker thread.  

However, then I had problems with giving effective feedback to the users while the image was being resized.  So, I added the "x_processing" booleans to the models, which worked well in the admin area, but the "missing.png" would get stuck in the public facing caching layer.

So I dug into the code and discovered the undocumented 'url_with_processing' configuration -- which, enables you to use the method called ".processing?", but turn off the "missing.png" piece.
