### PR TITLE
Add support for Sidekiq 3.x

### DIFF
--- a/delayed_paperclip.gemspec
+++ b/delayed_paperclip.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'delayed_job'
   s.add_development_dependency 'delayed_job_active_record'
   s.add_development_dependency 'resque'
-  s.add_development_dependency 'sidekiq', '< 3.0'
+  s.add_development_dependency 'sidekiq'
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'bundler'

--- a/gemfiles/rails3_1.gemfile.lock
+++ b/gemfiles/rails3_1.gemfile.lock
@@ -159,5 +159,5 @@ DEPENDENCIES
   rake
   resque
   rspec
-  sidekiq (< 3.0)
+  sidekiq
   sqlite3

--- a/gemfiles/rails3_2.gemfile.lock
+++ b/gemfiles/rails3_2.gemfile.lock
@@ -157,5 +157,5 @@ DEPENDENCIES
   rake
   resque
   rspec
-  sidekiq (< 3.0)
+  sidekiq
   sqlite3

--- a/gemfiles/rails4.gemfile.lock
+++ b/gemfiles/rails4.gemfile.lock
@@ -153,5 +153,5 @@ DEPENDENCIES
   rake
   resque
   rspec
-  sidekiq (< 3.0)
+  sidekiq
   sqlite3

--- a/spec/integration/sidekiq_spec.rb
+++ b/spec/integration/sidekiq_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'sidekiq'
+require 'sidekiq/api'
 
 describe "Sidekiq" do
 


### PR DESCRIPTION
It seems like the API that delayed_paperclip uses internally doesn't change from Sidekiq 2.x to 3.x. The only thing that changed is that you now have to explicitly `require sidekiq/api` in the test files to get access to `Sidekiq::Queue`. Changing `require sidekiq` to `require sidekiq/api` seems to work with both Sidekiq versions. At least it works for me locally with and without an update to Sidekiq 3.x.
