### PR TITLE
Fix setting post_processing to false without delay

### DIFF
--- a/lib/delayed_paperclip/attachment.rb
+++ b/lib/delayed_paperclip/attachment.rb
@@ -12,7 +12,7 @@ module DelayedPaperclip
     module InstanceMethods
 
       def delayed_options
-        @options[:delayed]
+        options[:delayed]
       end
 
       # Attr accessor in Paperclip
@@ -35,9 +35,8 @@ module DelayedPaperclip
       end
 
       def split_processing?
-        options[:only_process] &&
-          options[:only_process] !=
-            options[:delayed][:only_process]
+        options[:only_process] && delayed_options &&
+          options[:only_process] != delayed_options[:only_process]
       end
 
       def processing?

--- a/spec/delayed_paperclip/attachment_spec.rb
+++ b/spec/delayed_paperclip/attachment_spec.rb
@@ -33,9 +33,18 @@ describe DelayedPaperclip::Attachment do
       dummy.image.stubs(:delay_processing?).returns true
       dummy.image.post_processing_with_delay.should be_false
     end
+
+    context "on a non-delayed image" do
+      let(:dummy_options) { { with_processed: false } }
+
+      it "is false if delay_processing? is true" do
+        dummy.image.stubs(:delay_processing?).returns true
+        dummy.image.post_processing_with_delay.should be_false
+      end
+    end
   end
 
-  describe "delay_processing?" do
+  describe "#delay_processing?" do
     it "returns delayed_options existence if post_processing_with_delay is nil" do
       dummy.image.post_processing_with_delay = nil
       dummy.image.delay_processing?.should be_true
@@ -47,7 +56,7 @@ describe DelayedPaperclip::Attachment do
     end
   end
 
-  describe "processing?" do
+  describe "#processing?" do
     it "delegates to the dummy instance" do
       dummy.expects(:image_processing?)
       dummy.image.processing?
@@ -62,7 +71,7 @@ describe DelayedPaperclip::Attachment do
     end
   end
 
-  describe "processing_stye?" do
+  describe "#processing_style?" do
     let(:style) { :background }
     let(:processing_style?) { dummy.image.processing_style?(style) }
 
@@ -107,7 +116,7 @@ describe DelayedPaperclip::Attachment do
     end
   end
 
-  describe "delayed_only_process" do
+  describe "#delayed_only_process" do
     context "without only_process options" do
       it "returns []" do
         expect(dummy.image.delayed_only_process).to eq []
@@ -135,7 +144,7 @@ describe DelayedPaperclip::Attachment do
     end
   end
 
-  describe "process_delayed!" do
+  describe "#process_delayed!" do
     it "sets job_is_processing to true" do
       dummy.image.expects(:job_is_processing=).with(true).once
       dummy.image.expects(:job_is_processing=).with(false).once


### PR DESCRIPTION
- Fixes #105 

I'm sure if this is the best solution or if it's even correct, but it seems to do the trick here. It doesn't clean up the `post_processing` flow though.
