### PR TITLE
Rewrite UrlGenerator to use inheritance

### DIFF
--- a/lib/delayed_paperclip/railtie.rb
+++ b/lib/delayed_paperclip/railtie.rb
@@ -26,7 +26,7 @@ module DelayedPaperclip
     def self.insert
       ActiveRecord::Base.send(:include, DelayedPaperclip::Glue)
       Paperclip::Attachment.send(:include, DelayedPaperclip::Attachment)
-      Paperclip::UrlGenerator.send(:include, DelayedPaperclip::UrlGenerator)
+      Paperclip::Attachment.default_options[:url_generator] = DelayedPaperclip::UrlGenerator
     end
   end
 end

--- a/lib/delayed_paperclip/url_generator.rb
+++ b/lib/delayed_paperclip/url_generator.rb
@@ -1,45 +1,31 @@
 require 'uri'
+require 'paperclip/url_generator'
 
 module DelayedPaperclip
-  module UrlGenerator
-    def self.included(base)
-      base.alias_method_chain :most_appropriate_url, :processed
-      base.alias_method_chain :timestamp_possible?, :processed
-      base.alias_method_chain :for, :processed
-    end
-
-    def for_with_processed(style_name, options)
-      most_appropriate_url = @attachment.processing_style?(style_name) ? most_appropriate_url(style_name) : most_appropriate_url_without_processed
-
-      escape_url_as_needed(
-        timestamp_as_needed(
-          @attachment_options[:interpolator].interpolate(most_appropriate_url, @attachment, style_name),
-          options
-      ), options)
-    end
-
+  class UrlGenerator < ::Paperclip::UrlGenerator
     # This method is a mess
-    def most_appropriate_url_with_processed(style = nil)
-      if @attachment.original_filename.nil? || delayed_default_url?(style)
-        if @attachment.delayed_options.nil? ||
-           @attachment.processing_image_url.nil? ||
-           !@attachment.processing?
+    def most_appropriate_url(style = nil)
+      if @attachment.processing_style?(style)
+        if @attachment.original_filename.nil? || delayed_default_url?(style)
 
-          default_url
+          if @attachment.delayed_options.nil? ||
+            @attachment.processing_image_url.nil? ||
+            !@attachment.processing?
+            default_url
+          else
+            @attachment.processing_image_url
+          end
+
         else
-          @attachment.processing_image_url
+          @attachment_options[:url]
         end
       else
-        @attachment_options[:url]
+        super()
       end
     end
 
-    def timestamp_possible_with_processed?
-      if delayed_default_url?
-        false
-      else
-        timestamp_possible_without_processed?
-      end
+    def timestamp_possible?
+      delayed_default_url? ? false : super
     end
 
     def delayed_default_url?(style = nil)
@@ -54,9 +40,7 @@ module DelayedPaperclip
 
     def processing?(style)
       return true if @attachment.processing?
-
       return @attachment.processing_style?(style) if style
     end
   end
-
 end

--- a/spec/delayed_paperclip/url_generator_spec.rb
+++ b/spec/delayed_paperclip/url_generator_spec.rb
@@ -10,13 +10,13 @@ describe DelayedPaperclip::UrlGenerator do
   let(:attachment) { dummy.image }
   let(:dummy_options) { {} }
 
-  describe "for_with_processed" do
+  describe "for" do
     before do
       attachment.stubs(:original_filename).returns "12k.png"
     end
 
     context "with split processing" do
-      # everything in this hash is passed to delayed_paperclip, expect for the
+      # everything in this hash is passed to delayed_paperclip, except for the
       # paperclip stuff
       let(:dummy_options) { {
         paperclip: {
@@ -60,9 +60,9 @@ describe DelayedPaperclip::UrlGenerator do
     end
   end
 
-  describe "#most_appropriate_url_with_processed" do
+  describe "#most_appropriate_url" do
     context "without delayed_default_url" do
-      subject { Paperclip::UrlGenerator.new(attachment, {url: "/blah/url.jpg"})}
+      subject { DelayedPaperclip::UrlGenerator.new(attachment, {url: "/blah/url.jpg"})}
 
       before :each do
         subject.stubs(:delayed_default_url?).returns false
@@ -73,7 +73,7 @@ describe DelayedPaperclip::UrlGenerator do
         end
 
         it "returns options url" do
-          subject.most_appropriate_url_with_processed.should == "/blah/url.jpg"
+          subject.most_appropriate_url.should == "/blah/url.jpg"
         end
       end
 
@@ -89,7 +89,7 @@ describe DelayedPaperclip::UrlGenerator do
 
           it "gets default url" do
             subject.expects(:default_url)
-            subject.most_appropriate_url_with_processed
+            subject.most_appropriate_url
           end
         end
 
@@ -105,7 +105,7 @@ describe DelayedPaperclip::UrlGenerator do
 
             it "gets default url" do
               subject.expects(:default_url)
-              subject.most_appropriate_url_with_processed
+              subject.most_appropriate_url
             end
           end
 
@@ -120,14 +120,14 @@ describe DelayedPaperclip::UrlGenerator do
               end
 
               it "gets processing url" do
-                subject.most_appropriate_url_with_processed.should == "/processing/image.jpg"
+                subject.most_appropriate_url.should == "/processing/image.jpg"
               end
             end
 
             context "and is not processing" do
               it "gets default url" do
                 subject.expects(:default_url)
-                subject.most_appropriate_url_with_processed
+                subject.most_appropriate_url
               end
             end
           end
@@ -136,8 +136,8 @@ describe DelayedPaperclip::UrlGenerator do
     end
   end
 
-  describe "#timestamp_possible_with_processed?" do
-    subject { Paperclip::UrlGenerator.new(attachment, {})}
+  describe "#timestamp_possible?" do
+    subject { DelayedPaperclip::UrlGenerator.new(attachment, {})}
 
     context "with delayed_default_url" do
       before :each do
@@ -145,7 +145,7 @@ describe DelayedPaperclip::UrlGenerator do
       end
 
       it "is false" do
-        subject.timestamp_possible_with_processed?.should be_false
+        subject.timestamp_possible?.should be_false
       end
     end
 
@@ -156,13 +156,13 @@ describe DelayedPaperclip::UrlGenerator do
 
       it "goes up the chain" do
         subject.expects(:timestamp_possible_without_processed?)
-        subject.timestamp_possible_with_processed?
+        subject.timestamp_possible?
       end
     end
   end
 
   describe "#delayed_default_url?" do
-    subject { Paperclip::UrlGenerator.new(attachment, {})}
+    subject { DelayedPaperclip::UrlGenerator.new(attachment, {})}
 
     before :each do
       attachment.stubs(:job_is_processing).returns false


### PR DESCRIPTION
This is not finished, but the boolean expressions in UrlGenerator are so messy that I just don't have time to figure out why there are 3 failing specs. The code should work, since I carefully wrote it to do exactly what the old code did (sans monkey-patching). I must move onto other tasks for now. :( Submitting it here to discuss/improve/throwaway in the mean time.