### PR TITLE
Timestamps were improperly escaped

### DIFF
--- a/lib/delayed_paperclip/url_generator.rb
+++ b/lib/delayed_paperclip/url_generator.rb
@@ -11,11 +11,12 @@ module DelayedPaperclip
     def for_with_processed(style_name, options)
       most_appropriate_url = @attachment.processing_style?(style_name) ? most_appropriate_url(style_name) : most_appropriate_url_without_processed
 
-      escape_url_as_needed(
-        timestamp_as_needed(
+      timestamp_as_needed(
+        escape_url_as_needed(
           @attachment_options[:interpolator].interpolate(most_appropriate_url, @attachment, style_name),
           options
-      ), options)
+        ),
+      options)
     end
 
     # This method is a mess

--- a/spec/delayed_paperclip/url_generator_spec.rb
+++ b/spec/delayed_paperclip/url_generator_spec.rb
@@ -57,6 +57,32 @@ describe DelayedPaperclip::UrlGenerator do
           expect(attachment.url(:online)).to eql "/system/dummies/images/000/000/001/online/12k.png"
         end
       end
+
+      context "should be able to escape (, ), [, and ]." do
+        def generate(expected, updated_at=nil)
+          mock_interpolator = MockInterpolator.new(result: expected)
+          options           = { interpolator: mock_interpolator }
+          url_generator     = Paperclip::UrlGenerator.new(attachment, options)
+          attachment.stubs(:updated_at).returns updated_at
+          url_generator.for(:style_name, {escape: true, timestamp: !!updated_at})
+        end
+
+
+        it "interpolates correctly without timestamp" do
+          expect(
+            "the%28expected%29result%5B%5D"
+          ).to be == generate("the(expected)result[]")
+        end
+
+        it "does not interpolate timestamp" do
+          expected = "the(expected)result[]"
+          updated_at = 1231231234
+
+          expect(
+            "the%28expected%29result%5B%5D?#{updated_at}"
+          ).to be == generate(expected, updated_at)
+        end
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,8 @@ Paperclip::Railtie.insert
 require 'delayed_paperclip/railtie'
 DelayedPaperclip::Railtie.insert
 
+
+
 # silence deprecation warnings in rails 4.2
 if ActiveRecord::Base.respond_to?(:raise_in_transactional_callbacks=)
   ActiveRecord::Base.raise_in_transactional_callbacks = true
@@ -48,6 +50,10 @@ RSpec.configure do |config|
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
 end
+
+# In order to not duplicate code directly from Paperclip's spec support
+# We're requiring the MockInterpolator object to be used
+require Gem.find_files("../spec/support/mock_interpolator").first
 
 Dir["./spec/integration/examples/*.rb"].sort.each {|f| require f}
 


### PR DESCRIPTION
Swaps the timestamp and escaping methods

Fixes #126