### PR TITLE
Support split processing with callable :only_process

### DIFF
--- a/lib/delayed_paperclip/attachment.rb
+++ b/lib/delayed_paperclip/attachment.rb
@@ -36,7 +36,7 @@ module DelayedPaperclip
 
       def split_processing?
         options[:only_process] && delayed_options &&
-          options[:only_process] != delayed_options[:only_process]
+          options[:only_process] != delayed_only_process
       end
 
       def processing?
@@ -47,7 +47,7 @@ module DelayedPaperclip
       def processing_style?(style)
         return false if !processing?
 
-        !split_processing? || delayed_options[:only_process].include?(style)
+        !split_processing? || delayed_only_process.include?(style)
       end
 
       def delayed_only_process

--- a/spec/delayed_paperclip/attachment_spec.rb
+++ b/spec/delayed_paperclip/attachment_spec.rb
@@ -96,19 +96,37 @@ describe DelayedPaperclip::Attachment do
         end
 
         context "when split processing" do
-          let(:dummy_options) { {
-            paperclip: {
-              styles: {
-                online: "400x400x",
-                background: "600x600x"
+          context "when delayed :only_process is an Array" do
+            let(:dummy_options) { {
+              paperclip: {
+                styles: {
+                  online: "400x400x",
+                  background: "600x600x"
+                },
+                only_process: [:online]
               },
-              only_process: [:online]
-            },
 
-            only_process: [:background]
-          }}
+              only_process: [:background]
+            }}
 
-          specify { expect(processing_style?).to be }
+            specify { expect(processing_style?).to be }
+          end
+
+          context "when delayed :only_process is callable" do
+            let(:dummy_options) { {
+              paperclip: {
+                styles: {
+                  online: "400x400x",
+                  background: "600x600x"
+                },
+                only_process: [:online]
+              },
+
+              only_process: lambda { |a| [:background] }
+            }}
+
+            specify { expect(processing_style?).to be }
+          end
         end
       end
     end
@@ -260,30 +278,41 @@ describe DelayedPaperclip::Attachment do
     } }
 
     context ":only_process option is set on attachment" do
+      let(:dummy_options) { {
+        paperclip: {
+          styles: paperclip_styles,
+          only_process: [:online]
+        },
+
+        only_process: delayed_only_process
+      }}
+
       context "processing different styles in background" do
-        let(:dummy_options) { {
-          paperclip: {
-            styles: paperclip_styles,
-            only_process: [:online]
-          },
+        context "when delayed :only_process is an Array" do
+          let(:delayed_only_process) { [:background] }
 
-          only_process: [:background]
-        }}
+          specify { expect(split_processing?).to be true }
+        end
 
-        specify { expect(split_processing?).to be true }
+        context "when delayed :only_process is callable" do
+          let(:delayed_only_process) { lambda { |a| [:background] } }
+
+          specify { expect(split_processing?).to be true }
+        end
       end
 
       context "processing same styles in background" do
-        let(:dummy_options) { {
-          paperclip: {
-            styles: paperclip_styles,
-            only_process: [:online]
-          },
+        context "when delayed :only_process is an Array" do
+          let(:delayed_only_process) { [:online] }
 
-          only_process: [:online]
-        }}
+          specify { expect(split_processing?).to be false }
+        end
 
-        specify { expect(split_processing?).to be false }
+        context "when delayed :only_process is callable" do
+          let(:delayed_only_process) { lambda { |a| [:online] } }
+
+          specify { expect(split_processing?).to be false }
+        end
       end
     end
 

--- a/spec/delayed_paperclip/attachment_spec.rb
+++ b/spec/delayed_paperclip/attachment_spec.rb
@@ -250,4 +250,51 @@ describe DelayedPaperclip::Attachment do
       dummy.image.instance_variable_get(:@post_processing_with_delay).should == true
     end
   end
+
+  describe "#split_processing?" do
+    let(:split_processing?) { dummy.image.split_processing? }
+
+    let(:paperclip_styles) { {
+      online: "400x400x",
+      background: "600x600x"
+    } }
+
+    context ":only_process option is set on attachment" do
+      context "processing different styles in background" do
+        let(:dummy_options) { {
+          paperclip: {
+            styles: paperclip_styles,
+            only_process: [:online]
+          },
+
+          only_process: [:background]
+        }}
+
+        specify { expect(split_processing?).to be true }
+      end
+
+      context "processing same styles in background" do
+        let(:dummy_options) { {
+          paperclip: {
+            styles: paperclip_styles,
+            only_process: [:online]
+          },
+
+          only_process: [:online]
+        }}
+
+        specify { expect(split_processing?).to be false }
+      end
+    end
+
+    context ":only_process option is not set on attachment" do
+      let(:dummy_options) { {
+        paperclip: {
+          styles: paperclip_styles
+        }
+      }}
+
+      specify { expect(split_processing?).to be false }
+    end
+  end
 end

--- a/spec/delayed_paperclip/attachment_spec.rb
+++ b/spec/delayed_paperclip/attachment_spec.rb
@@ -105,9 +105,7 @@ describe DelayedPaperclip::Attachment do
               only_process: [:online]
             },
 
-            delayed_paperclip: {
-              only_process: [:background]
-            }
+            only_process: [:background]
           }}
 
           specify { expect(processing_style?).to be }


### PR DESCRIPTION
This fixes a bug that was preventing something like this:

````ruby
class User < ActiveRecord::Base
  has_attached_file :avatar, styles: { small: "25x25#", medium: "50x50x", large: "100x100x" }, only_process: [:small]

  process_in_background :avatar, only_process: lambda { |a| a.instance.large_supported? ? [:medium, :large] : [:medium] }
end
````

Also fixes a ``#processing_style?`` spec and adds coverage for ``#split_processing?``