### PR TITLE
Update README to demonstrate passing an interpolation string to processing_image_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ images currently being processed.
 class User < ActiveRecord::Base
   has_attached_file :avatar
 
-  process_in_background :avatar, processing_image_url: "/images/original/processing.jpg"
+  process_in_background :avatar, processing_image_url: "/images/:style/processing.jpg"
 end
 
 @user = User.new(avatar: File.new(...))


### PR DESCRIPTION
It wasn't immediately obvious to me (and maybe some others, see #118) that the string given to `processing_image_url` would be passed through the interpolator based on the previous example. This should make it clearer that you can include interpolation placeholders, making it easy to have per-style processing images.