### PR TITLE
Fixes for deprecation warnings in specs

### DIFF
--- a/spec/delayed_paperclip/attachment_spec.rb
+++ b/spec/delayed_paperclip/attachment_spec.rb
@@ -26,12 +26,12 @@ describe DelayedPaperclip::Attachment do
   describe "#post_processing_with_delay" do
     it "is true if delay_processing? is false" do
       dummy.image.stubs(:delay_processing?).returns false
-      dummy.image.post_processing_with_delay.should be_true
+      dummy.image.post_processing_with_delay.should be_truthy
     end
 
     it "is false if delay_processing? is true" do
       dummy.image.stubs(:delay_processing?).returns true
-      dummy.image.post_processing_with_delay.should be_false
+      dummy.image.post_processing_with_delay.should be_falsey
     end
 
     context "on a non-delayed image" do
@@ -39,7 +39,7 @@ describe DelayedPaperclip::Attachment do
 
       it "is false if delay_processing? is true" do
         dummy.image.stubs(:delay_processing?).returns true
-        dummy.image.post_processing_with_delay.should be_false
+        dummy.image.post_processing_with_delay.should be_falsey
       end
     end
   end
@@ -47,12 +47,12 @@ describe DelayedPaperclip::Attachment do
   describe "#delay_processing?" do
     it "returns delayed_options existence if post_processing_with_delay is nil" do
       dummy.image.post_processing_with_delay = nil
-      dummy.image.delay_processing?.should be_true
+      dummy.image.delay_processing?.should be_truthy
     end
 
     it "returns inverse of post_processing_with_delay if it's set" do
       dummy.image.post_processing_with_delay = true
-      dummy.image.delay_processing?.should be_false
+      dummy.image.delay_processing?.should be_falsey
     end
   end
 
@@ -66,7 +66,7 @@ describe DelayedPaperclip::Attachment do
       let(:dummy_options) { { with_processed: false } }
 
       it "returns false" do
-        expect(dummy.image.processing?).to be_false
+        expect(dummy.image.processing?).to be_falsey
       end
     end
   end
@@ -78,21 +78,21 @@ describe DelayedPaperclip::Attachment do
     context "without a processing column" do
       let(:dummy_options) { { with_processed: true, process_column: false } }
 
-      specify { expect(processing_style?).to be_false }
+      specify { expect(processing_style?).to be_falsey }
     end
 
     context "with a processing column" do
       context "when not processing" do
         before { dummy.image_processing = false }
 
-        specify { expect(processing_style?).to be_false }
+        specify { expect(processing_style?).to be_falsey }
       end
 
       context "when processing" do
         before { dummy.image_processing = true }
 
         context "when not split processing" do
-          specify { expect(processing_style?).to be_true }
+          specify { expect(processing_style?).to be_truthy }
         end
 
         context "when split processing" do
@@ -220,7 +220,7 @@ describe DelayedPaperclip::Attachment do
 
       dummy.image.send(:update_processing_column)
 
-      dummy.image_processing.should be_false
+      dummy.image_processing.should be_falsey
     end
   end
 

--- a/spec/delayed_paperclip/instance_methods_spec.rb
+++ b/spec/delayed_paperclip/instance_methods_spec.rb
@@ -34,16 +34,16 @@ describe DelayedPaperclip::InstanceMethods do
 
   describe "#mark_enqueue_delayed_processing" do
     it "updates columns of _processing" do
-      dummy.image_processing.should be_false
+      dummy.image_processing.should be_falsey
       dummy.instance_variable_set(:@_enqued_for_processing_with_processing, ['image'])
       dummy.mark_enqueue_delayed_processing
-      dummy.reload.image_processing.should be_true
+      dummy.reload.image_processing.should be_truthy
     end
 
     it "does nothing if instance variable not set" do
-      dummy.image_processing.should be_false
+      dummy.image_processing.should be_falsey
       dummy.mark_enqueue_delayed_processing
-      dummy.reload.image_processing.should be_false
+      dummy.reload.image_processing.should be_falsey
     end
   end
 
@@ -56,9 +56,9 @@ describe DelayedPaperclip::InstanceMethods do
 
   describe "#prepare_enqueueing_for" do
     it "updates processing column to true" do
-      dummy.image_processing.should be_false
+      dummy.image_processing.should be_falsey
       dummy.prepare_enqueueing_for("image")
-      dummy.image_processing.should be_true
+      dummy.image_processing.should be_truthy
     end
 
     it "sets instance variables for column updating" do

--- a/spec/delayed_paperclip/url_generator_spec.rb
+++ b/spec/delayed_paperclip/url_generator_spec.rb
@@ -171,7 +171,7 @@ describe DelayedPaperclip::UrlGenerator do
       end
 
       it "is false" do
-        subject.timestamp_possible_with_processed?.should be_false
+        subject.timestamp_possible_with_processed?.should be_falsey
       end
     end
 
@@ -200,7 +200,7 @@ describe DelayedPaperclip::UrlGenerator do
     end
 
     it "has all false, delayed_default_url returns true" do
-      subject.delayed_default_url?.should be_true
+      subject.delayed_default_url?.should be_truthy
     end
 
     context "job is processing" do
@@ -209,7 +209,7 @@ describe DelayedPaperclip::UrlGenerator do
       end
 
       it "returns true" do
-        subject.delayed_default_url?.should be_false
+        subject.delayed_default_url?.should be_falsey
       end
     end
 
@@ -219,7 +219,7 @@ describe DelayedPaperclip::UrlGenerator do
       end
 
       it "returns true" do
-        subject.delayed_default_url?.should be_false
+        subject.delayed_default_url?.should be_falsey
       end
     end
 
@@ -229,7 +229,7 @@ describe DelayedPaperclip::UrlGenerator do
       end
 
       it "returns true" do
-        subject.delayed_default_url?.should be_false
+        subject.delayed_default_url?.should be_falsey
       end
     end
 
@@ -240,7 +240,7 @@ describe DelayedPaperclip::UrlGenerator do
       end
 
       it "returns true" do
-        subject.delayed_default_url?.should be_false
+        subject.delayed_default_url?.should be_falsey
       end
     end
 

--- a/spec/integration/base_delayed_paperclip_spec.rb
+++ b/spec/integration/base_delayed_paperclip_spec.rb
@@ -14,15 +14,15 @@ describe "Base Delayed Paperclip Integration" do
 
   describe "double save" do
     before :each do
-      dummy.image_processing.should be_false
+      dummy.image_processing.should be_falsey
       dummy.image = File.open("#{ROOT}/spec/fixtures/12k.png")
       dummy.save!
     end
 
     it "processing column remains true" do
-      dummy.image_processing.should be_true
+      dummy.image_processing.should be_truthy
       dummy.save!
-      dummy.image_processing.should be_true
+      dummy.image_processing.should be_truthy
     end
   end
 

--- a/spec/integration/examples/base.rb
+++ b/spec/integration/examples/base.rb
@@ -12,10 +12,10 @@ shared_examples "base usage" do
 
     it "allows normal paperclip functionality" do
       Paperclip::Attachment.any_instance.expects(:post_process)
-      dummy.image.delay_processing?.should be_false
-      dummy.image.post_processing.should be_true
-      dummy.save.should be_true
-      File.exists?(dummy.image.path).should be_true
+      dummy.image.delay_processing?.should be_falsey
+      dummy.image.post_processing.should be_truthy
+      dummy.save.should be_truthy
+      File.exists?(dummy.image.path).should be_truthy
     end
 
     context "missing url" do
@@ -52,16 +52,16 @@ shared_examples "base usage" do
       dummy.image.post_processing = true
     end
     it "has delay_processing is false" do
-      dummy.image.delay_processing?.should be_false
+      dummy.image.delay_processing?.should be_falsey
     end
 
     it "post processing returns true" do
-      dummy.image.post_processing.should be_true
+      dummy.image.post_processing.should be_truthy
     end
 
     it "writes the file" do
       dummy.save
-      File.exists?(dummy.image.path).should be_true
+      File.exists?(dummy.image.path).should be_truthy
     end
   end
 
@@ -73,16 +73,16 @@ shared_examples "base usage" do
     end
 
     it "delays processing" do
-      dummy.image.delay_processing?.should be_true
+      dummy.image.delay_processing?.should be_truthy
     end
 
     it "post_processing is false" do
-      dummy.image.post_processing.should be_false
+      dummy.image.post_processing.should be_falsey
     end
 
     it "has file after save" do
       dummy.save
-      File.exists?(dummy.image.path).should be_true
+      File.exists?(dummy.image.path).should be_truthy
     end
 
   end
@@ -98,9 +98,9 @@ shared_examples "base usage" do
   describe "processing column not altered" do
     it "resets after job finished" do
       dummy.save!
-      dummy.image_processing?.should be_true
+      dummy.image_processing?.should be_truthy
       process_jobs
-      dummy.reload.image_processing?.should be_false
+      dummy.reload.image_processing?.should be_falsey
     end
 
     context "with error" do
@@ -110,10 +110,10 @@ shared_examples "base usage" do
 
       it "stays true even if errored" do
         dummy.save!
-        dummy.image_processing?.should be_true
+        dummy.image_processing?.should be_truthy
         process_jobs
-        dummy.image_processing?.should be_true
-        dummy.reload.image_processing?.should be_true
+        dummy.image_processing?.should be_truthy
+        dummy.reload.image_processing?.should be_truthy
       end
     end
   end
@@ -121,10 +121,10 @@ shared_examples "base usage" do
   # TODO: test appears redundant
   describe "processing is true for new record" do
     it "is true" do
-      dummy.image_processing?.should be_false
-      dummy.new_record?.should be_true
+      dummy.image_processing?.should be_falsey
+      dummy.new_record?.should be_truthy
       dummy.save!
-      dummy.reload.image_processing?.should be_true
+      dummy.reload.image_processing?.should be_truthy
     end
   end
 
@@ -243,7 +243,7 @@ shared_examples "base usage" do
       dummy.save!
       process_jobs
       dummy.reload.image.url(:thumbnail).should start_with("/system/dummies/images/000/000/001/thumbnail/12k.jpg")
-      File.exists?(dummy.image.path).should be_true
+      File.exists?(dummy.image.path).should be_truthy
     end
   end
 
@@ -259,9 +259,9 @@ shared_examples "base usage" do
 
     it "does not increase jobs count" do
       dummy.save!
-      dummy.image_processing?.should be_true
+      dummy.image_processing?.should be_truthy
       process_jobs
-      dummy.reload.image_processing?.should be_false
+      dummy.reload.image_processing?.should be_falsey
 
       Paperclip::Attachment.any_instance.expects(:reprocess!).once
 
@@ -269,8 +269,8 @@ shared_examples "base usage" do
       dummy.image.reprocess_without_delay!(:thumbnail)
       existing_jobs.should == jobs_count
 
-      dummy.image_processing?.should be_false
-      File.exists?(dummy.image.path).should be_true
+      dummy.image_processing?.should be_falsey
+      File.exists?(dummy.image.path).should be_truthy
     end
 
   end


### PR DESCRIPTION
Fixes deprecation warnings while running the tests.
This pull request replaces `be_true` and `be_false` with `be_truthy` and `be_falsey` respectively.