### PR TITLE
Solve issue 101

### DIFF
--- a/lib/delayed_paperclip.rb
+++ b/lib/delayed_paperclip.rb
@@ -31,9 +31,9 @@ module DelayedPaperclip
     end
 
     def process_job(instance_klass, instance_id, attachment_name)
-      instance_klass.constantize.unscoped.find(instance_id).
-        send(attachment_name).
-        process_delayed!
+      if instance = instance_klass.constantize.unscoped.where(id: instance_id).first
+        instance.send(attachment_name).process_delayed!
+      end
     end
 
   end

--- a/spec/delayed_paperclip_spec.rb
+++ b/spec/delayed_paperclip_spec.rb
@@ -32,10 +32,19 @@ describe DelayedPaperclip do
 
     it "finds dummy and calls #process_delayed!" do
       dummy_stub = stub
-      dummy_stub.expects(:find).with(dummy.id).returns(dummy)
+      dummy_stub.expects(:where).with(id: dummy.id).returns([dummy])
       Dummy.expects(:unscoped).returns(dummy_stub)
       dummy.image.expects(:process_delayed!)
       DelayedPaperclip.process_job("Dummy", dummy.id, :image)
+    end
+
+    it "doesn't find dummy and it doesn't raise any exceptions" do
+      dummy_stub = stub
+      dummy_stub.expects(:where).with(id: dummy.id).returns([])
+      Dummy.expects(:unscoped).returns(dummy_stub)
+      expect do
+        DelayedPaperclip.process_job("Dummy", dummy.id, :image)
+      end.not_to raise_exception
     end
   end
 


### PR DESCRIPTION
Hey @jrgifford! 

At my company, we encountered issue #101 while trying to use `delayed_paperclip` with Sidekiq. 

I think that the best solution would be to ignore instances that have been deleted before the background job gets to the processing part.

Please check it out and let me know if it looks good. 

Thanks! 
