### PR TITLE
Default queue names from delayed_paperclip_defaults and Delayed::Worker.default_queue_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,8 @@ module YourApp
 
     config.delayed_paperclip_defaults = {
         url_with_processing: true,
-        processing_image_url: 'custom_processing.png'
+        processing_image_url: 'custom_processing.png',
+        queue: 'foo'
     }
   end
 end

--- a/lib/delayed_paperclip.rb
+++ b/lib/delayed_paperclip.rb
@@ -59,7 +59,7 @@ module DelayedPaperclip
         :only_process => only_process_default,
         :url_with_processing => DelayedPaperclip.options[:url_with_processing],
         :processing_image_url => DelayedPaperclip.options[:processing_image_url],
-        :queue => nil
+        :queue => DelayedPaperclip.options[:queue]
       }.each do |option, default|
 
         paperclip_definitions[name][:delayed][option] = options.key?(option) ? options[option] : default

--- a/lib/delayed_paperclip/jobs/delayed_job.rb
+++ b/lib/delayed_paperclip/jobs/delayed_job.rb
@@ -10,7 +10,7 @@ module DelayedPaperclip
           ::Delayed::Job.enqueue(
             :payload_object => new(instance_klass, instance_id, attachment_name),
             :priority => instance_klass.constantize.paperclip_definitions[attachment_name][:delayed][:priority].to_i,
-            :queue => instance_klass.constantize.paperclip_definitions[attachment_name][:delayed][:queue]
+            :queue => instance_klass.constantize.paperclip_definitions[attachment_name][:delayed][:queue] || Delayed::Worker.default_queue_name
           )
         end
 

--- a/spec/delayed_paperclip_spec.rb
+++ b/spec/delayed_paperclip_spec.rb
@@ -56,7 +56,13 @@ describe DelayedPaperclip do
 
   describe "paperclip definitions" do
     before :each do
+      DelayedPaperclip.options[:queue] = "bar"
       reset_dummy :paperclip => { styles: { thumbnail: "25x25"} }
+    end
+
+    after :each do
+      DelayedPaperclip.options[:queue] = nil
+      reset_dummy
     end
 
     it "returns paperclip options regardless of version" do
@@ -65,7 +71,7 @@ describe DelayedPaperclip do
                                                             :only_process => [],
                                                             :url_with_processing => true,
                                                             :processing_image_url => nil,
-                                                            :queue => nil}
+                                                            :queue => "bar"}
                                                           }
                                               }
     end

--- a/spec/integration/delayed_job_spec.rb
+++ b/spec/integration/delayed_job_spec.rb
@@ -17,7 +17,7 @@ describe "Delayed Job" do
 
   describe "delayed_job default queue name" do
     before :all do
-      Delayed::Worker.default_queue_name = "bar"
+      Delayed::Worker.default_queue_name = "foo"
       reset_dummy
     end
 
@@ -26,7 +26,17 @@ describe "Delayed Job" do
       reset_dummy
     end
 
-    it "should match" do
+    it "should be used when not overridden" do
+      ::Delayed::Job.expects(:enqueue).with do |params|
+        params[:queue].should == "foo"
+      end
+      dummy.image = File.open("#{ROOT}/spec/fixtures/12k.png")
+      dummy.save!
+    end
+
+    it "should not be used if overridden" do
+      DelayedPaperclip.options[:queue] = "bar"
+      reset_dummy
       ::Delayed::Job.expects(:enqueue).with do |params|
         params[:queue].should == "bar"
       end
@@ -59,15 +69,15 @@ describe "Delayed Job" do
 
   def build_delayed_jobs
     ActiveRecord::Base.connection.create_table :delayed_jobs, :force => true do |table|
-      table.integer :priority, :default => 0 # Allows some jobs to jump to the front of the queue
-      table.integer :attempts, :default => 0 # Provides for retries, but still fail eventually.
-      table.text :handler # YAML-encoded string of the object that will do work
-      table.string :last_error # reason for last failure (See Note below)
-      table.datetime :run_at # When to run. Could be Time.now for immediately, or sometime in the future.
-      table.datetime :locked_at # Set when a client is working on this object
-      table.datetime :failed_at # Set when all retries have failed (actually, by default, the record is deleted instead)
-      table.string :locked_by # Who is working on this object (if locked)
-      table.string :queue
+      table.integer   :priority,  :default => 0   # Allows some jobs to jump to the front of the queue
+      table.integer   :attempts,  :default => 0   # Provides for retries, but still fail eventually.
+      table.text      :handler                    # YAML-encoded string of the object that will do work
+      table.string    :last_error                 # reason for last failure (See Note below)
+      table.datetime  :run_at                     # When to run. Could be Time.now for immediately, or sometime in the future.
+      table.datetime  :locked_at                  # Set when a client is working on this object
+      table.datetime  :failed_at                  # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string    :locked_by                  # Who is working on this object (if locked)
+      table.string    :queue
       table.timestamps null: true
     end
   end

--- a/spec/integration/delayed_job_spec.rb
+++ b/spec/integration/delayed_job_spec.rb
@@ -15,6 +15,26 @@ describe "Delayed Job" do
     include_examples "base usage"
   end
 
+  describe "delayed_job default queue name" do
+    before :all do
+      Delayed::Worker.default_queue_name = "bar"
+      reset_dummy
+    end
+
+    after :all do
+      Delayed::Worker.default_queue_name = nil
+      reset_dummy
+    end
+
+    it "should match" do
+      ::Delayed::Job.expects(:enqueue).with do |params|
+        params[:queue].should == "bar"
+      end
+      dummy.image = File.open("#{ROOT}/spec/fixtures/12k.png")
+      dummy.save!
+    end
+  end
+
   describe "perform job" do
     before :each do
       DelayedPaperclip.options[:url_with_processing] = true
@@ -39,15 +59,15 @@ describe "Delayed Job" do
 
   def build_delayed_jobs
     ActiveRecord::Base.connection.create_table :delayed_jobs, :force => true do |table|
-      table.integer  :priority, :default => 0      # Allows some jobs to jump to the front of the queue
-      table.integer  :attempts, :default => 0      # Provides for retries, but still fail eventually.
-      table.text     :handler                      # YAML-encoded string of the object that will do work
-      table.string   :last_error                   # reason for last failure (See Note below)
-      table.datetime :run_at                       # When to run. Could be Time.now for immediately, or sometime in the future.
-      table.datetime :locked_at                    # Set when a client is working on this object
-      table.datetime :failed_at                    # Set when all retries have failed (actually, by default, the record is deleted instead)
-      table.string   :locked_by                    # Who is working on this object (if locked)
-      table.string   :queue
+      table.integer :priority, :default => 0 # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, :default => 0 # Provides for retries, but still fail eventually.
+      table.text :handler # YAML-encoded string of the object that will do work
+      table.string :last_error # reason for last failure (See Note below)
+      table.datetime :run_at # When to run. Could be Time.now for immediately, or sometime in the future.
+      table.datetime :locked_at # Set when a client is working on this object
+      table.datetime :failed_at # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by # Who is working on this object (if locked)
+      table.string :queue
       table.timestamps null: true
     end
   end


### PR DESCRIPTION
* When using a version of delayed_job that supports a default queue name, delayed_paperclip should also use that queue if specified.
* config.delayed_paperclip_defaults should allow you to set the default queue name for delayed_paperclip to use just as the other delayed_paperclip defaults function.

Handles issue brought up in #43