### PR TITLE
Fixed running tests with random order

### DIFF
--- a/spec/delayed_paperclip/class_methods_spec.rb
+++ b/spec/delayed_paperclip/class_methods_spec.rb
@@ -1,14 +1,12 @@
 require 'spec_helper'
 
 describe DelayedPaperclip::ClassMethods do
-
-  before :all do
+  before :each do
     DelayedPaperclip.options[:background_job_class] = DelayedPaperclip::Jobs::Resque
     reset_dummy(with_processed: false)
   end
 
   describe ".process_in_background" do
-
     it "is empty to start" do
       Dummy.paperclip_definitions.should == { :image => {} }
     end
@@ -73,16 +71,13 @@ describe DelayedPaperclip::ClassMethods do
       end
 
       context "save" do
-        before :each do
-          Dummy.stubs(:respond_to?).with(:after_commit).returns(false)
-        end
-
         it "sets after_save callback" do
+          Dummy.stubs(:respond_to?).with(:attachment_definitions).returns(true)
+          Dummy.stubs(:respond_to?).with(:after_commit).returns(false)
           Dummy.expects(:after_save).with(:enqueue_delayed_processing)
           Dummy.process_in_background(:image)
         end
       end
     end
   end
-
 end

--- a/spec/delayed_paperclip/instance_methods_spec.rb
+++ b/spec/delayed_paperclip/instance_methods_spec.rb
@@ -1,8 +1,7 @@
 require 'spec_helper'
 
 describe DelayedPaperclip::InstanceMethods do
-
-  before :all do
+  before :each do
     DelayedPaperclip.options[:background_job_class] = DelayedPaperclip::Jobs::Resque
     reset_dummy
   end
@@ -10,7 +9,6 @@ describe DelayedPaperclip::InstanceMethods do
   let(:dummy) { Dummy.create }
 
   describe "#enqueue_delayed_processing" do
-
     it "marks enqueue_delayed_processing" do
       dummy.expects(:mark_enqueue_delayed_processing)
       dummy.enqueue_delayed_processing
@@ -29,7 +27,6 @@ describe DelayedPaperclip::InstanceMethods do
       dummy.instance_variable_get(:@_enqued_for_processing).should == []
       dummy.instance_variable_get(:@_enqued_for_processing_with_processing).should == []
     end
-
   end
 
   describe "#mark_enqueue_delayed_processing" do
@@ -71,6 +68,4 @@ describe DelayedPaperclip::InstanceMethods do
       dummy.instance_variable_get(:@_enqued_for_processing).should == ["image"]
     end
   end
-
-
 end

--- a/spec/delayed_paperclip/url_generator_spec.rb
+++ b/spec/delayed_paperclip/url_generator_spec.rb
@@ -11,7 +11,7 @@ describe DelayedPaperclip::UrlGenerator do
   let(:dummy_options) { {} }
 
   describe "for" do
-    before do
+    before :each do
       attachment.stubs(:original_filename).returns "12k.png"
     end
 
@@ -31,7 +31,7 @@ describe DelayedPaperclip::UrlGenerator do
       }}
 
       context "processing" do
-        before do
+        before :each do
           attachment.stubs(:processing?).returns true
         end
 
@@ -45,7 +45,7 @@ describe DelayedPaperclip::UrlGenerator do
       end
 
       context "not processing" do
-        before do
+        before :each do
           attachment.stubs(:processing?).returns false
         end
 

--- a/spec/delayed_paperclip_spec.rb
+++ b/spec/delayed_paperclip_spec.rb
@@ -2,28 +2,34 @@ require 'spec_helper'
 require 'resque'
 
 describe DelayedPaperclip do
-  before :all do
+  before :each do
     reset_dummy
   end
 
-  describe ".options" do
-    it ".options returns basic options" do
-      DelayedPaperclip.options.should == {:background_job_class => DelayedPaperclip::Jobs::Resque,
-                                          :url_with_processing => true,
-                                          :processing_image_url => nil}
+  context "with Resque adapter" do
+    before :each do
+      DelayedPaperclip.options[:background_job_class] = DelayedPaperclip::Jobs::Resque
     end
-  end
 
-  describe ".processor" do
-    it ".processor returns processor" do
-      DelayedPaperclip.processor.should == DelayedPaperclip::Jobs::Resque
+    describe ".options" do
+      it ".options returns basic options" do
+        DelayedPaperclip.options.should == {:background_job_class => DelayedPaperclip::Jobs::Resque,
+                                            :url_with_processing => true,
+                                            :processing_image_url => nil}
+      end
     end
-  end
 
-  describe ".enqueue" do
-    it "delegates to processor" do
-      DelayedPaperclip::Jobs::Resque.expects(:enqueue_delayed_paperclip).with("Dummy", 1, :image)
-      DelayedPaperclip.enqueue("Dummy", 1, :image)
+    describe ".processor" do
+      it ".processor returns processor" do
+        DelayedPaperclip.processor.should == DelayedPaperclip::Jobs::Resque
+      end
+    end
+
+    describe ".enqueue" do
+      it "delegates to processor" do
+        DelayedPaperclip::Jobs::Resque.expects(:enqueue_delayed_paperclip).with("Dummy", 1, :image)
+        DelayedPaperclip.enqueue("Dummy", 1, :image)
+      end
     end
   end
 
@@ -49,7 +55,7 @@ describe DelayedPaperclip do
   end
 
   describe "paperclip definitions" do
-    before :all do
+    before :each do
       reset_dummy :paperclip => { styles: { thumbnail: "25x25"} }
     end
 
@@ -63,6 +69,5 @@ describe DelayedPaperclip do
                                                           }
                                               }
     end
-
   end
 end

--- a/spec/integration/active_job_inline_spec.rb
+++ b/spec/integration/active_job_inline_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe "ActiveJob inline" do
-
   if defined? ActiveJob
-    before :all do
+    before :each do
       DelayedPaperclip.options[:background_job_class] = DelayedPaperclip::Jobs::ActiveJob
+      ActiveJob::Base.queue_adapter = :inline
       ActiveJob::Base.logger = nil
     end
 

--- a/spec/integration/active_job_resque_spec.rb
+++ b/spec/integration/active_job_resque_spec.rb
@@ -3,8 +3,7 @@ require 'resque'
 
 if defined? ActiveJob
   describe "Active Job with Resque backend" do
-
-    before :all do
+    before :each do
       DelayedPaperclip.options[:background_job_class] = DelayedPaperclip::Jobs::ActiveJob
       ActiveJob::Base.logger = nil
       ActiveJob::Base.queue_adapter = :resque
@@ -23,9 +22,7 @@ if defined? ActiveJob
     end
 
     def jobs_count
-
       Resque.size(:paperclip)
     end
-
   end
 end

--- a/spec/integration/active_job_sidekiq_spec.rb
+++ b/spec/integration/active_job_sidekiq_spec.rb
@@ -2,24 +2,23 @@ require 'spec_helper'
 require 'sidekiq/api'
 
 describe "ActiveJob with Sidekiq backend" do
+  if defined? ActiveJob
+    before :each do
+      DelayedPaperclip.options[:background_job_class] = DelayedPaperclip::Jobs::ActiveJob
+      ActiveJob::Base.logger = nil
+      ActiveJob::Base.queue_adapter = :sidekiq
+    end
 
-if defined? ActiveJob
-  before :all do
-    DelayedPaperclip.options[:background_job_class] = DelayedPaperclip::Jobs::ActiveJob
-    ActiveJob::Base.logger = nil
-    ActiveJob::Base.queue_adapter = :sidekiq
+    before :each do
+      Sidekiq::Queues["paperclip"].clear
+    end
+
+    let(:dummy) { Dummy.new(:image => File.open("#{ROOT}/spec/fixtures/12k.png")) }
+
+    describe "integration tests" do
+      include_examples "base usage"
+    end
   end
-
-  before :each do
-    Sidekiq::Queues["paperclip"].clear
-  end
-
-  let(:dummy) { Dummy.new(:image => File.open("#{ROOT}/spec/fixtures/12k.png")) }
-
-  describe "integration tests" do
-    include_examples "base usage"
-  end
-end
 
   def process_jobs
     Sidekiq::Queues["paperclip"].each do |job|

--- a/spec/integration/base_delayed_paperclip_spec.rb
+++ b/spec/integration/base_delayed_paperclip_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe "Base Delayed Paperclip Integration" do
-  before :all do
+  before :each do
     DelayedPaperclip.options[:background_job_class] = DelayedPaperclip::Jobs::Resque
     Resque.remove_queue(:paperclip)
   end
@@ -25,5 +25,4 @@ describe "Base Delayed Paperclip Integration" do
       dummy.image_processing.should be_truthy
     end
   end
-
 end

--- a/spec/integration/delayed_job_spec.rb
+++ b/spec/integration/delayed_job_spec.rb
@@ -4,8 +4,7 @@ require 'delayed_job'
 Delayed::Worker.backend = :active_record
 
 describe "Delayed Job" do
-
-  before :all do
+  before :each do
     DelayedPaperclip.options[:background_job_class] = DelayedPaperclip::Jobs::DelayedJob
     build_delayed_jobs
   end

--- a/spec/integration/resque_spec.rb
+++ b/spec/integration/resque_spec.rb
@@ -2,8 +2,7 @@ require 'spec_helper'
 require 'resque'
 
 describe "Resque" do
-
-  before :all do
+  before :each do
     DelayedPaperclip.options[:background_job_class] = DelayedPaperclip::Jobs::Resque
     Resque.remove_queue(:paperclip)
   end
@@ -36,5 +35,4 @@ describe "Resque" do
   def jobs_count
     Resque.size(:paperclip)
   end
-
 end

--- a/spec/integration/sidekiq_spec.rb
+++ b/spec/integration/sidekiq_spec.rb
@@ -2,12 +2,9 @@ require 'spec_helper'
 require 'sidekiq/testing'
 
 describe "Sidekiq" do
-  before :all do
+  before :each do
     Sidekiq.logger.level = Logger::ERROR
     DelayedPaperclip.options[:background_job_class] = DelayedPaperclip::Jobs::Sidekiq
-  end
-
-  before :each do
     Sidekiq::Queues["paperclip"].clear
   end
 
@@ -45,5 +42,4 @@ describe "Sidekiq" do
   def jobs_count
     Sidekiq::Queues["paperclip"].size
   end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,8 +48,22 @@ Paperclip.logger = ActiveRecord::Base.logger
 RSpec.configure do |config|
   config.mock_with :mocha
 
+  config.order = :random
+
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
+
+  config.before(:each) do
+    reset_global_default_options
+  end
+end
+
+def reset_global_default_options
+  DelayedPaperclip.options.merge!({
+    :background_job_class => DelayedPaperclip::Jobs::Resque,
+    :url_with_processing  => true,
+    :processing_image_url => nil
+  })
 end
 
 # In order to not duplicate code directly from Paperclip's spec support


### PR DESCRIPTION
I was trying to move forward with https://github.com/jrgifford/delayed_paperclip/pull/161 but I had issues with tests.
Test state was leaking into other tests, so it was not possible sometimes to run them in isolation.
Hopefully now all are order independent.