### PR TITLE
Allow to set queue name for background jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,19 @@ end
 @user.avatar.reprocess_without_delay!(:medium)
 ````
 
+#### Set queue name
+
+You can set queue name for background job. By default it's called "paperclip".
+You can set it by changing global default options or by:
+
+```
+class User < ActiveRecord::Base
+  has_attached_file :avatar
+
+  process_in_background :avatar, queue: "default"
+end
+```
+
 Defaults
 --------
 

--- a/lib/delayed_paperclip.rb
+++ b/lib/delayed_paperclip.rb
@@ -11,7 +11,8 @@ module DelayedPaperclip
       @options ||= {
         :background_job_class => detect_background_task,
         :url_with_processing  => true,
-        :processing_image_url => nil
+        :processing_image_url => nil,
+        :queue => "paperclip"
       }
     end
 
@@ -59,11 +60,9 @@ module DelayedPaperclip
         :only_process => only_process_default,
         :url_with_processing => DelayedPaperclip.options[:url_with_processing],
         :processing_image_url => DelayedPaperclip.options[:processing_image_url],
-        :queue => nil
+        :queue => DelayedPaperclip.options[:queue]
       }.each do |option, default|
-
         paperclip_definitions[name][:delayed][option] = options.key?(option) ? options[option] : default
-
       end
 
       # Sets callback

--- a/lib/delayed_paperclip/jobs/active_job.rb
+++ b/lib/delayed_paperclip/jobs/active_job.rb
@@ -1,11 +1,9 @@
 module DelayedPaperclip
   module Jobs
     class ActiveJob < ActiveJob::Base
-      queue_as :paperclip
-
       def self.enqueue_delayed_paperclip(instance_klass, instance_id, attachment_name)
-        # ActiveJob currently does not support symbol arguments
-        self.perform_later(instance_klass, instance_id, attachment_name.to_s)
+        queue_name = instance_klass.constantize.paperclip_definitions[attachment_name][:delayed][:queue]
+        set(:queue => queue_name).perform_later(instance_klass, instance_id, attachment_name.to_s)
       end
 
       def perform(instance_klass, instance_id, attachment_name)

--- a/lib/delayed_paperclip/jobs/delayed_job.rb
+++ b/lib/delayed_paperclip/jobs/delayed_job.rb
@@ -4,7 +4,8 @@ module DelayedPaperclip
   module Jobs
     class DelayedJob < Struct.new(:instance_klass, :instance_id, :attachment_name)
 
-      if Gem.loaded_specs['delayed_job'].version >= Gem::Version.new("2.1.0") # this is available in newer versions of DelayedJob. Using the newee Job api thus.
+      # This is available in newer versions of DelayedJob. Using the newee Job api thus.
+      if Gem.loaded_specs['delayed_job'].version >= Gem::Version.new("2.1.0")
 
         def self.enqueue_delayed_paperclip(instance_klass, instance_id, attachment_name)
           ::Delayed::Job.enqueue(

--- a/lib/delayed_paperclip/jobs/resque.rb
+++ b/lib/delayed_paperclip/jobs/resque.rb
@@ -3,9 +3,8 @@ require 'resque'
 module DelayedPaperclip
   module Jobs
     class Resque
-      @queue = :paperclip
-
       def self.enqueue_delayed_paperclip(instance_klass, instance_id, attachment_name)
+        @queue = instance_klass.constantize.paperclip_definitions[attachment_name][:delayed][:queue]
         ::Resque.enqueue(self, instance_klass, instance_id, attachment_name)
       end
 

--- a/lib/delayed_paperclip/jobs/sidekiq.rb
+++ b/lib/delayed_paperclip/jobs/sidekiq.rb
@@ -4,9 +4,15 @@ module DelayedPaperclip
   module Jobs
     class Sidekiq
       include ::Sidekiq::Worker
-      sidekiq_options :queue => :paperclip
 
       def self.enqueue_delayed_paperclip(instance_klass, instance_id, attachment_name)
+        queue_name = instance_klass.constantize.paperclip_definitions[attachment_name][:delayed][:queue]
+        # Sidekiq >= 4.1.0
+        if respond_to?(:set)
+          set(:queue => queue_name)
+        else
+          sidekiq_options :queue => queue_name
+        end
         perform_async(instance_klass, instance_id, attachment_name)
       end
 

--- a/spec/delayed_paperclip/attachment_spec.rb
+++ b/spec/delayed_paperclip/attachment_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe DelayedPaperclip::Attachment do
-
   before :each do
     DelayedPaperclip.options[:background_job_class] = DelayedPaperclip::Jobs::Resque
     reset_dummy(dummy_options)
@@ -11,15 +10,14 @@ describe DelayedPaperclip::Attachment do
   let(:dummy) { Dummy.create }
 
   describe "#delayed_options" do
-
     it "returns the specific options for delayed paperclip" do
-      dummy.image.delayed_options.should == {
+      expect(dummy.image.delayed_options).to eq({
         :priority => 0,
         :only_process => [],
         :url_with_processing => true,
         :processing_image_url => nil,
-        :queue => nil
-      }
+        :queue => "paperclip"
+      })
     end
   end
 

--- a/spec/delayed_paperclip/class_methods_spec.rb
+++ b/spec/delayed_paperclip/class_methods_spec.rb
@@ -19,9 +19,22 @@ describe DelayedPaperclip::ClassMethods do
           :only_process => [],
           :url_with_processing => true,
           :processing_image_url => nil,
-          :queue => nil}
+          :queue => "paperclip"}
         }
       }
+    end
+
+    it "allows to set queue name" do
+      Dummy.process_in_background(:image, :queue => "custom")
+      expect(Dummy.paperclip_definitions).to eq({ :image => {
+        :delayed => {
+          :priority => 0,
+          :only_process => [],
+          :url_with_processing => true,
+          :processing_image_url => nil,
+          :queue => "custom"}
+        }
+      })
     end
 
     context "with processing_image_url" do
@@ -36,7 +49,7 @@ describe DelayedPaperclip::ClassMethods do
             :only_process => [],
             :url_with_processing => true,
             :processing_image_url => "/processing/url",
-            :queue => nil}
+            :queue => "paperclip"}
           }
         }
       end
@@ -56,7 +69,7 @@ describe DelayedPaperclip::ClassMethods do
             :only_process => [:small, :large],
             :url_with_processing => true,
             :processing_image_url => nil,
-            :queue => nil}
+            :queue => "paperclip"}
           }
         }
       end

--- a/spec/delayed_paperclip/instance_methods_spec.rb
+++ b/spec/delayed_paperclip/instance_methods_spec.rb
@@ -23,6 +23,7 @@ describe DelayedPaperclip::InstanceMethods do
     it "clears instance variables" do
       dummy.instance_variable_set(:@_enqued_for_processing, ['foo'])
       dummy.instance_variable_set(:@_enqued_for_processing_with_processing, ['image'])
+      dummy.expects(:enqueue_post_processing_for).with('foo')
       dummy.enqueue_delayed_processing
       dummy.instance_variable_get(:@_enqued_for_processing).should == []
       dummy.instance_variable_get(:@_enqued_for_processing_with_processing).should == []

--- a/spec/delayed_paperclip_spec.rb
+++ b/spec/delayed_paperclip_spec.rb
@@ -15,7 +15,8 @@ describe DelayedPaperclip do
       it ".options returns basic options" do
         DelayedPaperclip.options.should == {:background_job_class => DelayedPaperclip::Jobs::Resque,
                                             :url_with_processing => true,
-                                            :processing_image_url => nil}
+                                            :processing_image_url => nil,
+                                            :queue => "paperclip"}
       end
     end
 
@@ -60,14 +61,14 @@ describe DelayedPaperclip do
     end
 
     it "returns paperclip options regardless of version" do
-      Dummy.paperclip_definitions.should ==  {:image =>   { :styles => { :thumbnail => "25x25" },
+      expect(Dummy.paperclip_definitions).to eq({:image =>   { :styles => { :thumbnail => "25x25" },
                                               :delayed => { :priority => 0,
                                                             :only_process => [],
                                                             :url_with_processing => true,
                                                             :processing_image_url => nil,
-                                                            :queue => nil}
+                                                            :queue => "paperclip"}
                                                           }
-                                              }
+                                              })
     end
   end
 end

--- a/spec/integration/active_job_resque_spec.rb
+++ b/spec/integration/active_job_resque_spec.rb
@@ -21,8 +21,8 @@ if defined? ActiveJob
       worker.process
     end
 
-    def jobs_count
-      Resque.size(:paperclip)
+    def jobs_count(queue = :paperclip)
+      Resque.size(queue)
     end
   end
 end

--- a/spec/integration/active_job_sidekiq_spec.rb
+++ b/spec/integration/active_job_sidekiq_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'sidekiq/api'
+require 'sidekiq/testing'
 
 describe "ActiveJob with Sidekiq backend" do
   if defined? ActiveJob
@@ -7,9 +7,6 @@ describe "ActiveJob with Sidekiq backend" do
       DelayedPaperclip.options[:background_job_class] = DelayedPaperclip::Jobs::ActiveJob
       ActiveJob::Base.logger = nil
       ActiveJob::Base.queue_adapter = :sidekiq
-    end
-
-    before :each do
       Sidekiq::Queues["paperclip"].clear
     end
 
@@ -31,7 +28,7 @@ describe "ActiveJob with Sidekiq backend" do
     end
   end
 
-  def jobs_count
-    Sidekiq::Queues["paperclip"].size
+  def jobs_count(queue = "paperclip")
+    Sidekiq::Queues[queue].size
   end
 end

--- a/spec/integration/delayed_job_spec.rb
+++ b/spec/integration/delayed_job_spec.rb
@@ -33,7 +33,7 @@ describe "Delayed Job" do
     Delayed::Worker.new.work_off
   end
 
-  def jobs_count
+  def jobs_count(queue = nil)
     Delayed::Job.count
   end
 

--- a/spec/integration/examples/base.rb
+++ b/spec/integration/examples/base.rb
@@ -312,4 +312,13 @@ shared_examples "base usage" do
     end
   end
 
+  describe "queue option" do
+    it "enqueues job with given queue name" do
+      reset_dummy :queue => "custom"
+
+      expect do
+        dummy.save!
+      end.to change { jobs_count("custom") }.by(1)
+    end
+  end
 end

--- a/spec/integration/resque_spec.rb
+++ b/spec/integration/resque_spec.rb
@@ -32,7 +32,7 @@ describe "Resque" do
     worker.process
   end
 
-  def jobs_count
-    Resque.size(:paperclip)
+  def jobs_count(queue = :paperclip)
+    Resque.size(queue)
   end
 end

--- a/spec/integration/sidekiq_spec.rb
+++ b/spec/integration/sidekiq_spec.rb
@@ -39,7 +39,7 @@ describe "Sidekiq" do
     end
   end
 
-  def jobs_count
-    Sidekiq::Queues["paperclip"].size
+  def jobs_count(queue = "paperclip")
+    Sidekiq::Queues[queue].size
   end
 end


### PR DESCRIPTION
@ScotterC This might be an incompatible change for some users.

* Previously delayed_job adapter queue name was nil - now defaults to "paperclip"
* Setting queue name changed a little in each adapter, so it may affect users that already changed it by hand, in example in AJ adapter it was possible before by:
```ruby
# Overwrite queue name which was "paperclip"
class DelayedPaperclip::Jobs::ActiveJob
  queue_as :default
end
```
which will no longer work now.
