### PR TITLE
Deprecate Resque, Sidekiq and DelayedJob adapters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ end
 
 ### Resque
 
+Resque adapter is deprecated. Please use ActiveJob one.
+
 Make sure that you have [Resque](https://github.com/resque/resque) up and running. The jobs will be
 dispatched to the <code>:paperclip</code> queue, so you can correctly
 dispatch your worker. Configure resque and your workers exactly as you
@@ -90,9 +92,13 @@ would otherwise.
 
 ### DJ
 
+DelayedJob adapter is deprecated. Please use ActiveJob one.
+
 Just make sure that you have DJ up and running.
 
 ### Sidekiq
+
+Sidekiq adapter is deprecated. Please use ActiveJob one.
 
 Make sure that [Sidekiq](http://github.com/mperham/sidekiq) is running and listening to the
 `paperclip` queue, either by adding it to your

--- a/lib/delayed_paperclip/jobs/delayed_job.rb
+++ b/lib/delayed_paperclip/jobs/delayed_job.rb
@@ -1,4 +1,5 @@
 require 'delayed_job'
+require 'active_support/deprecation'
 
 module DelayedPaperclip
   module Jobs
@@ -8,6 +9,11 @@ module DelayedPaperclip
       if Gem.loaded_specs['delayed_job'].version >= Gem::Version.new("2.1.0")
 
         def self.enqueue_delayed_paperclip(instance_klass, instance_id, attachment_name)
+          ActiveSupport::Deprecation.warn(<<-MESSAGE)
+Using DelayedJob adapter for delayed_paperclip is deprecated and will be removed in version 3.0.0.
+Please use ActiveJob adapter.
+          MESSAGE
+
           ::Delayed::Job.enqueue(
             :payload_object => new(instance_klass, instance_id, attachment_name),
             :priority => instance_klass.constantize.paperclip_definitions[attachment_name][:delayed][:priority].to_i,
@@ -18,6 +24,11 @@ module DelayedPaperclip
       else
 
         def self.enqueue_delayed_paperclip(instance_klass, instance_id, attachment_name)
+          ActiveSupport::Deprecation.warn(<<-MESSAGE)
+Using DelayedJob adapter for delayed_paperclip is deprecated and will be removed in version 3.0.0.
+Please use ActiveJob adapter.
+          MESSAGE
+
           ::Delayed::Job.enqueue(
             new(instance_klass, instance_id, attachment_name),
             instance_klass.constantize.paperclip_definitions[attachment_name][:delayed][:priority].to_i,

--- a/lib/delayed_paperclip/jobs/resque.rb
+++ b/lib/delayed_paperclip/jobs/resque.rb
@@ -1,4 +1,5 @@
 require 'resque'
+require 'active_support/deprecation'
 
 module DelayedPaperclip
   module Jobs
@@ -6,6 +7,11 @@ module DelayedPaperclip
       def self.enqueue_delayed_paperclip(instance_klass, instance_id, attachment_name)
         @queue = instance_klass.constantize.paperclip_definitions[attachment_name][:delayed][:queue]
         ::Resque.enqueue(self, instance_klass, instance_id, attachment_name)
+
+        ActiveSupport::Deprecation.warn(<<-MESSAGE)
+Using Resque adapter for delayed_paperclip is deprecated and will be removed in version 3.0.0.
+Please use ActiveJob adapter.
+        MESSAGE
       end
 
       def self.perform(instance_klass, instance_id, attachment_name)

--- a/lib/delayed_paperclip/jobs/sidekiq.rb
+++ b/lib/delayed_paperclip/jobs/sidekiq.rb
@@ -1,4 +1,5 @@
 require 'sidekiq/worker'
+require 'active_support/deprecation'
 
 module DelayedPaperclip
   module Jobs
@@ -6,6 +7,11 @@ module DelayedPaperclip
       include ::Sidekiq::Worker
 
       def self.enqueue_delayed_paperclip(instance_klass, instance_id, attachment_name)
+        ActiveSupport::Deprecation.warn(<<-MESSAGE)
+Using Sidekiq adapter for delayed_paperclip is deprecated and will be removed in version 3.0.0.
+Please use ActiveJob adapter.
+        MESSAGE
+
         queue_name = instance_klass.constantize.paperclip_definitions[attachment_name][:delayed][:queue]
         # Sidekiq >= 4.1.0
         if respond_to?(:set)

--- a/spec/integration/delayed_job_spec.rb
+++ b/spec/integration/delayed_job_spec.rb
@@ -27,6 +27,15 @@ describe "Delayed Job" do
       dummy.save!
       Delayed::Job.last.payload_object.perform
     end
+
+    it "is deprecated" do
+      ActiveSupport::Deprecation.expects(:warn)
+
+      dummy.image = File.open("#{ROOT}/fixtures/12k.png")
+      Paperclip::Attachment.any_instance.expects(:reprocess!)
+      dummy.save!
+      Delayed::Job.last.payload_object.perform
+    end
   end
 
   def process_jobs

--- a/spec/integration/resque_spec.rb
+++ b/spec/integration/resque_spec.rb
@@ -25,6 +25,15 @@ describe "Resque" do
       dummy.save!
       DelayedPaperclip::Jobs::Resque.perform(dummy.class.name, dummy.id, :image)
     end
+
+    it "is deprecated" do
+      ActiveSupport::Deprecation.expects(:warn)
+
+      dummy.image = File.open("#{ROOT}/fixtures/12k.png")
+      Paperclip::Attachment.any_instance.expects(:reprocess!)
+      dummy.save!
+      DelayedPaperclip::Jobs::Resque.perform(dummy.class.name, dummy.id, :image)
+    end
   end
 
   def process_jobs

--- a/spec/integration/sidekiq_spec.rb
+++ b/spec/integration/sidekiq_spec.rb
@@ -26,6 +26,15 @@ describe "Sidekiq" do
       dummy.save!
       DelayedPaperclip::Jobs::Sidekiq.new.perform(dummy.class.name, dummy.id, :image)
     end
+
+    it "is deprecated" do
+      ActiveSupport::Deprecation.expects(:warn)
+
+      dummy.image = File.open("#{ROOT}/fixtures/12k.png")
+      Paperclip::Attachment.any_instance.expects(:reprocess!)
+      dummy.save!
+      DelayedPaperclip::Jobs::Sidekiq.new.perform(dummy.class.name, dummy.id, :image)
+    end
   end
 
   def process_jobs

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,9 @@ if ActiveRecord::Base.respond_to?(:raise_in_transactional_callbacks=) && Rails::
   ActiveRecord::Base.raise_in_transactional_callbacks = true
 end
 
+require "active_support/deprecation"
+ActiveSupport::Deprecation.silenced = true
+
 # Connect to sqlite
 ActiveRecord::Base.establish_connection(
   "adapter" => "sqlite3",


### PR DESCRIPTION
For better maintenance of gem `delayed_paperclip` will only support
`ActiveJob` adapter which is available by default since Rails 4.2.
It's possible to use any of this 3 background job adapters through AJ.

@ScotterC Please take a look if we are on the same page.
In version 3.0:
* remove all adapters except AJ
* bump required Ruby version to 2.0
* bump required Rails version to 4.2

If that's the plan, can you please merge it and release 2.10.0 with this deprecation warnings?
