### PR TITLE
Revert pull request #152 - "Solve issue 101"

### DIFF
--- a/lib/delayed_paperclip.rb
+++ b/lib/delayed_paperclip.rb
@@ -32,9 +32,9 @@ module DelayedPaperclip
     end
 
     def process_job(instance_klass, instance_id, attachment_name)
-      if instance = instance_klass.constantize.unscoped.where(id: instance_id).first
-        instance.send(attachment_name).process_delayed!
-      end
+      instance_klass.constantize.unscoped.find(instance_id).
+        send(attachment_name).
+        process_delayed!
     end
 
   end

--- a/spec/delayed_paperclip_spec.rb
+++ b/spec/delayed_paperclip_spec.rb
@@ -39,19 +39,10 @@ describe DelayedPaperclip do
 
     it "finds dummy and calls #process_delayed!" do
       dummy_stub = stub
-      dummy_stub.expects(:where).with(id: dummy.id).returns([dummy])
+      dummy_stub.expects(:find).with(dummy.id).returns(dummy)
       Dummy.expects(:unscoped).returns(dummy_stub)
       dummy.image.expects(:process_delayed!)
       DelayedPaperclip.process_job("Dummy", dummy.id, :image)
-    end
-
-    it "doesn't find dummy and it doesn't raise any exceptions" do
-      dummy_stub = stub
-      dummy_stub.expects(:where).with(id: dummy.id).returns([])
-      Dummy.expects(:unscoped).returns(dummy_stub)
-      expect do
-        DelayedPaperclip.process_job("Dummy", dummy.id, :image)
-      end.not_to raise_exception
     end
   end
 


### PR DESCRIPTION
This reverts PR https://github.com/jrgifford/delayed_paperclip/pull/152.

Rationale: https://github.com/jrgifford/delayed_paperclip/pull/152#issuecomment-231407728

This off course unsolves the original requester's bug. I would argue that the original requester's problem should be solved like this instead:

```ruby
class MyClass < ActiveRecord::Base
  # ... paperclip and delayed_paperclip definitions here

  before_destroy :dequeue_delayed_paperclip_job

  def dequeue_delayed_paperclip_job
    queue = Sidekiq::Queue.new("my_queue")
    queue.each do |job|
      if job.klass == 'DelayedPaperclip::Jobs::Sidekiq' &&
        job.args == ['MyClass', self.id, 'my_attachment_name']
        job.delete
      end
    end
  end
end
```

Above code is originally taken from http://stackoverflow.com/a/21101810.

An alternative solution could be:

```ruby
# in config/initializers/delayed_paperclip.rb
DelayedPaperclip.options[:background_job_class] = MyCustomJob

class MyCustomJob
  include ::Sidekiq::Worker

  def self.enqueue_delayed_paperclip(*args)
    perform_async(*args)
  end

  def perform(*args)
    DelayedPaperclip.process_job(*args)
  rescue ActiveRecord::RecordNotFound
    # do nothing
  end
end
```

What do you think? cc @etagwerker @ScotterC @fabiolnm