### PR TITLE
Use Module#prepend instead of alias to override Paperclip::Attachment…

### DIFF
--- a/lib/delayed_paperclip/attachment.rb
+++ b/lib/delayed_paperclip/attachment.rb
@@ -1,105 +1,89 @@
 module DelayedPaperclip
   module Attachment
+    attr_accessor :job_is_processing
 
-    def self.included(base)
-      base.send :include, InstanceMethods
-      base.send :attr_accessor, :job_is_processing
-
-      base.send :alias_method, :post_processing_without_delay, :post_processing
-      base.send :alias_method, :post_processing, :post_processing_with_delay
-
-      base.send :alias_method, :post_processing_without_delay=, :post_processing=
-      base.send :alias_method, :post_processing=, :post_processing_with_delay=
-
-      base.send :alias_method, :save_without_prepare_enqueueing, :save
-      base.send :alias_method, :save, :save_with_prepare_enqueueing
+    def delayed_options
+      options[:delayed]
     end
 
-    module InstanceMethods
-
-      def delayed_options
-        options[:delayed]
-      end
-
-      # Attr accessor in Paperclip
-      def post_processing_with_delay
-        !delay_processing? || split_processing?
-      end
-
-      def post_processing_with_delay=(value)
-        @post_processing_with_delay = value
-      end
-
-      # if nil, returns whether it has delayed options
-      # if set, then it returns
-      def delay_processing?
-        if @post_processing_with_delay.nil?
-          !!delayed_options
-        else
-          !@post_processing_with_delay
-        end
-      end
-
-      def split_processing?
-        options[:only_process] && delayed_options &&
-          options[:only_process] != delayed_only_process
-      end
-
-      def processing?
-        column_name = :"#{@name}_processing?"
-        @instance.respond_to?(column_name) && @instance.send(column_name)
-      end
-
-      def processing_style?(style)
-        return false if !processing?
-
-        !split_processing? || delayed_only_process.include?(style)
-      end
-
-      def delayed_only_process
-        only_process = delayed_options.fetch(:only_process, []).dup
-        only_process = only_process.call(self) if only_process.respond_to?(:call)
-        only_process.map(&:to_sym)
-      end
-
-      def process_delayed!
-        self.job_is_processing = true
-        self.post_processing = true
-        reprocess!(*delayed_only_process)
-        self.job_is_processing = false
-        update_processing_column
-      end
-
-      def processing_image_url
-        processing_image_url = delayed_options[:processing_image_url]
-        processing_image_url = processing_image_url.call(self) if processing_image_url.respond_to?(:call)
-        processing_image_url
-      end
-
-      def save_with_prepare_enqueueing
-        was_dirty = @dirty
-
-        save_without_prepare_enqueueing.tap do
-          if delay_processing? && was_dirty
-            instance.prepare_enqueueing_for name
-          end
-        end
-      end
-
-      def reprocess_without_delay!(*style_args)
-        @post_processing_with_delay = true
-        reprocess!(*style_args)
-      end
-
-      private
-
-      def update_processing_column
-        if instance.respond_to?(:"#{name}_processing?")
-          instance.send("#{name}_processing=", false)
-          instance.class.where(instance.class.primary_key => instance.id).update_all({ "#{name}_processing" => false })
-        end
-      end
-
+    # Attr accessor in Paperclip
+    def post_processing
+      !delay_processing? || split_processing?
     end
+
+    def post_processing=(value)
+      @post_processing_with_delay = value
+    end
+
+    # if nil, returns whether it has delayed options
+    # if set, then it returns
+    def delay_processing?
+      if @post_processing_with_delay.nil?
+        !!delayed_options
+      else
+        !@post_processing_with_delay
+      end
+    end
+
+    def split_processing?
+      options[:only_process] && delayed_options &&
+        options[:only_process] != delayed_only_process
+    end
+
+    def processing?
+      column_name = :"#{@name}_processing?"
+      @instance.respond_to?(column_name) && @instance.send(column_name)
+    end
+
+    def processing_style?(style)
+      return false if !processing?
+
+      !split_processing? || delayed_only_process.include?(style)
+    end
+
+    def delayed_only_process
+      only_process = delayed_options.fetch(:only_process, []).dup
+      only_process = only_process.call(self) if only_process.respond_to?(:call)
+      only_process.map(&:to_sym)
+    end
+
+    def process_delayed!
+      self.job_is_processing = true
+      self.post_processing = true
+      reprocess!(*delayed_only_process)
+      self.job_is_processing = false
+      update_processing_column
+    end
+
+    def processing_image_url
+      processing_image_url = delayed_options[:processing_image_url]
+      processing_image_url = processing_image_url.call(self) if processing_image_url.respond_to?(:call)
+      processing_image_url
+    end
+
+    def save
+      was_dirty = @dirty
+
+      super.tap do
+        if delay_processing? && was_dirty
+          instance.prepare_enqueueing_for name
+        end
+      end
+    end
+
+    def reprocess_without_delay!(*style_args)
+      @post_processing_with_delay = true
+      reprocess!(*style_args)
+    end
+
+    private
+
+    def update_processing_column
+      if instance.respond_to?(:"#{name}_processing?")
+        instance.send("#{name}_processing=", false)
+        instance.class.where(instance.class.primary_key => instance.id).update_all({ "#{name}_processing" => false })
+      end
+    end
+
   end
 end

--- a/lib/delayed_paperclip/railtie.rb
+++ b/lib/delayed_paperclip/railtie.rb
@@ -20,7 +20,7 @@ module DelayedPaperclip
     # Attachment and URL Generator extends Paperclip
     def self.insert
       ActiveRecord::Base.send(:include, DelayedPaperclip::Glue)
-      Paperclip::Attachment.send(:include, DelayedPaperclip::Attachment)
+      Paperclip::Attachment.prepend(DelayedPaperclip::Attachment)
       Paperclip::Attachment.default_options[:url_generator] = DelayedPaperclip::UrlGenerator
     end
   end

--- a/spec/delayed_paperclip/attachment_spec.rb
+++ b/spec/delayed_paperclip/attachment_spec.rb
@@ -23,12 +23,12 @@ describe DelayedPaperclip::Attachment do
   describe "#post_processing_with_delay" do
     it "is true if delay_processing? is false" do
       dummy.image.stubs(:delay_processing?).returns false
-      dummy.image.post_processing_with_delay.should be_truthy
+      dummy.image.post_processing.should be_truthy
     end
 
     it "is false if delay_processing? is true" do
       dummy.image.stubs(:delay_processing?).returns true
-      dummy.image.post_processing_with_delay.should be_falsey
+      dummy.image.post_processing.should be_falsey
     end
 
     context "on a non-delayed image" do
@@ -36,19 +36,19 @@ describe DelayedPaperclip::Attachment do
 
       it "is false if delay_processing? is true" do
         dummy.image.stubs(:delay_processing?).returns true
-        dummy.image.post_processing_with_delay.should be_falsey
+        dummy.image.post_processing.should be_falsey
       end
     end
   end
 
   describe "#delay_processing?" do
-    it "returns delayed_options existence if post_processing_with_delay is nil" do
-      dummy.image.post_processing_with_delay = nil
+    it "returns delayed_options existence if post_processing is nil" do
+      dummy.image.post_processing = nil
       dummy.image.delay_processing?.should be_truthy
     end
 
-    it "returns inverse of post_processing_with_delay if it's set" do
-      dummy.image.post_processing_with_delay = true
+    it "returns inverse of post_processing if it's set" do
+      dummy.image.post_processing = true
       dummy.image.delay_processing?.should be_falsey
     end
   end
@@ -237,7 +237,7 @@ describe DelayedPaperclip::Attachment do
     end
   end
 
-  describe "#save_with_prepare_enqueueing" do
+  describe "#save" do
     context "delay processing and it was dirty" do
       before :each do
         dummy.image.stubs(:delay_processing?).returns true
@@ -246,14 +246,14 @@ describe DelayedPaperclip::Attachment do
 
       it "prepares the enqueing" do
         dummy.expects(:prepare_enqueueing_for).with(:image)
-        dummy.image.save_with_prepare_enqueueing
+        dummy.image.save
       end
     end
 
     context "without dirty or delay_processing" do
       it "does not prepare_enqueueing" do
         dummy.expects(:prepare_enqueueing_for).with(:image).never
-        dummy.image.save_with_prepare_enqueueing
+        dummy.image.save
       end
     end
   end


### PR DESCRIPTION
Hi,

I'm working on getting paperclip_meta to play nice with Rails 5 and in the process noticed the change in #162 removing `alias_method_chain`. I believe the point of deprecating alias_method_chain is that Module#prepend is cleaner, so doing what #162 does (basically re-implementing a_m_c) seems to miss the point, unless you're trying to support Ruby 1.9 for some reason.

I replaced all the `alias :this, :that` calls and used Module#prepend in the Railtie. Not totally sure about the naming of the `@post_processing_with_delay` instance variable, but I left it in because it didn't seem right to just use`@post_processing`.