### PR TITLE
Paperclip 5.1.0 no longer passes attachment_options

### DIFF
--- a/lib/delayed_paperclip/url_generator.rb
+++ b/lib/delayed_paperclip/url_generator.rb
@@ -12,7 +12,7 @@ module DelayedPaperclip
       most_appropriate_url = @attachment.processing_style?(style_name) ? most_appropriate_url(style_name) : most_appropriate_url()
       timestamp_as_needed(
         escape_url_as_needed(
-          @attachment_options[:interpolator].interpolate(most_appropriate_url, @attachment, style_name),
+          @attachment.options[:interpolator].interpolate(most_appropriate_url, @attachment, style_name),
           options
         ),
       options)
@@ -32,7 +32,7 @@ module DelayedPaperclip
           end
 
         else
-          @attachment_options[:url]
+          @attachment.options[:url]
         end
       else
         super()


### PR DESCRIPTION
Change to fix compatibility with Paperclip 5.1.0 as they no longer pass @attachment_options - https://github.com/thoughtbot/paperclip/commit/09d6bb7865c06de9e4b90328f507977ae6146814#diff-a4870b4fe431f88fa95c85e4c819ad4f #