### PR TITLE
Stop memoizing paperclip_definitions (fixes #129)

### DIFF
--- a/lib/delayed_paperclip.rb
+++ b/lib/delayed_paperclip.rb
@@ -65,7 +65,7 @@ module DelayedPaperclip
     end
 
     def paperclip_definitions
-      @paperclip_definitions ||= if respond_to? :attachment_definitions
+      if respond_to? :attachment_definitions
         attachment_definitions
       else
         Paperclip::Tasks::Attachments.definitions_for(self)


### PR DESCRIPTION
Perhaps it's also time to stop falling back to `Paperclip::Tasks::Attachments` since that got changed [waaaaaaaaaaaay back in Paperclip 3.5.1](https://github.com/thoughtbot/paperclip/commit/b62cc2d), almost four years ago now...