### PR TITLE
handle invalid instance_id

### DIFF
--- a/lib/delayed_paperclip.rb
+++ b/lib/delayed_paperclip.rb
@@ -23,7 +23,10 @@ module DelayedPaperclip
     end
 
     def process_job(instance_klass, instance_id, attachment_name)
-      instance_klass.constantize.unscoped.find(instance_id).
+      instance = instance_klass.constantize.unscoped.where(id: instance_id).first
+      return if instance.blank?
+
+      instance.
         send(attachment_name).
         process_delayed!
     end

--- a/spec/delayed_paperclip_spec.rb
+++ b/spec/delayed_paperclip_spec.rb
@@ -30,9 +30,17 @@ describe DelayedPaperclip do
   describe ".process_job" do
     let(:dummy) { Dummy.create! }
 
+    it "returns early on invalid id" do
+      dummy_stub = stub
+      dummy_stub.expects(:where).with(id: dummy.id).returns([])
+      Dummy.expects(:unscoped).returns(dummy_stub)
+      dummy.image.expects(:process_delayed!).never
+      DelayedPaperclip.process_job("Dummy", dummy.id, :image)
+    end
+
     it "finds dummy and calls #process_delayed!" do
       dummy_stub = stub
-      dummy_stub.expects(:find).with(dummy.id).returns(dummy)
+      dummy_stub.expects(:where).with(id: dummy.id).returns([dummy])
       Dummy.expects(:unscoped).returns(dummy_stub)
       dummy.image.expects(:process_delayed!)
       DelayedPaperclip.process_job("Dummy", dummy.id, :image)


### PR DESCRIPTION
fixes issue #205 
Currently hard fails on RecordNotFound. This can happen if the record is deleted before delayed_paperclip gets to processing it. 

Fix returns early and does not attempt to process a record that doesn't exist.