### PR TITLE
ignore default scopes when marking attachments as in processing

### DIFF
--- a/lib/delayed_paperclip.rb
+++ b/lib/delayed_paperclip.rb
@@ -93,7 +93,7 @@ module DelayedPaperclip
       unless @_enqued_for_processing_with_processing.blank? # catches nil and empty arrays
         updates = @_enqued_for_processing_with_processing.collect{|n| "#{n}_processing = :true" }.join(", ")
         updates = ActiveRecord::Base.send(:sanitize_sql_array, [updates, {:true => true}])
-        self.class.where(:id => self.id).update_all(updates)
+        self.class.unscoped.where(:id => self.id).update_all(updates)
       end
     end
 

--- a/lib/delayed_paperclip/attachment.rb
+++ b/lib/delayed_paperclip/attachment.rb
@@ -81,7 +81,7 @@ module DelayedPaperclip
     def update_processing_column
       if instance.respond_to?(:"#{name}_processing?")
         instance.send("#{name}_processing=", false)
-        instance.class.where(instance.class.primary_key => instance.id).update_all({ "#{name}_processing" => false })
+        instance.class.unscoped.where(instance.class.primary_key => instance.id).update_all({ "#{name}_processing" => false })
       end
     end
 

--- a/spec/delayed_paperclip/attachment_spec.rb
+++ b/spec/delayed_paperclip/attachment_spec.rb
@@ -235,7 +235,24 @@ describe DelayedPaperclip::Attachment do
 
       dummy.image.send(:update_processing_column)
 
-      dummy.image_processing.should be_falsey
+      dummy.reload.image_processing.should be_falsey
+    end
+
+    context 'with a  default scope on the model excluding the instance' do
+      let(:dummy_options) do
+        { :default_scope => lambda { Dummy.where(hidden: false) } }
+      end
+
+      let!(:dummy) { Dummy.create(hidden: true) }
+
+      specify { Dummy.count.should be 0 }
+      specify { Dummy.unscoped.count.should be 1 }
+
+      it "ignores the default scope and updates the column to false" do
+        dummy.update_attribute(:image_processing, true)
+        dummy.image.send(:update_processing_column)
+        dummy.reload.image_processing.should be_falsey
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -83,6 +83,7 @@ def build_dummy_table(with_column)
     t.string   :image_content_type
     t.integer  :image_file_size
     t.datetime :image_updated_at
+    t.boolean :hidden, :default => false
     t.boolean(:image_processing, :default => false) if with_column
   end
 end
@@ -107,6 +108,8 @@ def reset_class(class_name, options)
     process_in_background :image, options if options[:with_processed]
 
     after_update :reprocess if options[:with_after_update_callback]
+
+    default_scope options[:default_scope] if options[:default_scope]
 
     def reprocess
       image.reprocess!


### PR DESCRIPTION
If adding an attachment to a model with a default scope on it, the 'in processing' flag does not get updated from true to false once delayed paperclip has finished its work, so the record is left marked as 'in processing' even after it's attachment has been processed. 

This pull request simply adds `unscoped` to ensure that default scopes are removed before running the 'in processing' updates, both when setting it to `true` and to `false`.