### PR TITLE
Making a touch on updated_at after attachment is processed

### DIFF
--- a/lib/delayed_paperclip/attachment.rb
+++ b/lib/delayed_paperclip/attachment.rb
@@ -79,7 +79,8 @@ module DelayedPaperclip
     private
 
     def update_processing_column
-      instance.send("#{name}_updated_at=", Time.now.to_i)
+      instance.send("#{name}_updated_at=", Time.now)
+      instance.class.unscoped.where(instance.class.primary_key => instance.id).update_all({ "#{name}_updated_at" => Time.now })
       if instance.respond_to?(:"#{name}_processing?")
         instance.send("#{name}_processing=", false)
         instance.class.unscoped.where(instance.class.primary_key => instance.id).update_all({ "#{name}_processing" => false })

--- a/lib/delayed_paperclip/attachment.rb
+++ b/lib/delayed_paperclip/attachment.rb
@@ -79,6 +79,7 @@ module DelayedPaperclip
     private
 
     def update_processing_column
+      instance.send("#{name}_updated_at=", Time.now.to_i)
       if instance.respond_to?(:"#{name}_processing?")
         instance.send("#{name}_processing=", false)
         instance.class.unscoped.where(instance.class.primary_key => instance.id).update_all({ "#{name}_processing" => false })


### PR DESCRIPTION
This will update the `#{name}_updated_at` field after processing the file.

By doing so it will enable people who uses CDNs to expire 404 errors caused by caching an access to the attachment url before the processing has finished.

# WHY? 

This is necessary because most CDN's configuration takes the query strings into consideration for caching, which changes when `#{name}_updated_at` changes. Changing query string will invalidate previous errors caused by not using a default "missing file" url.

@jrgifford 